### PR TITLE
Fix :unknown_attributes assignment for ArrayType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## master
+- [PR #34](https://github.com/DmitryTsepelev/store_model/pull/34) Fix `#unknown_attributes` assignment for `ArrayType`
 
 ## 0.5.2 (2019-08-23)
 

--- a/lib/store_model/types/array_type.rb
+++ b/lib/store_model/types/array_type.rb
@@ -69,14 +69,18 @@ module StoreModel
       # rubocop:disable Style/RescueModifier
       def decode_and_initialize(array_value)
         decoded = ActiveSupport::JSON.decode(array_value) rescue []
-        decoded.map { |attributes| @model_klass.new(attributes) }
+        decoded.map { |attributes| cast_model_type_value(attributes) }
       end
       # rubocop:enable Style/RescueModifier
 
       def ensure_model_class(array)
         array.map do |object|
-          object.is_a?(@model_klass) ? object : @model_klass.new(object)
+          object.is_a?(@model_klass) ? object : cast_model_type_value(object)
         end
+      end
+
+      def cast_model_type_value(value)
+        @model_klass.to_type.cast_value(value)
       end
     end
   end

--- a/lib/store_model/types/array_type.rb
+++ b/lib/store_model/types/array_type.rb
@@ -14,6 +14,7 @@ module StoreModel
       # @return [StoreModel::Types::ArrayType]
       def initialize(model_klass)
         @model_klass = model_klass
+        @model_klass_type = model_klass.to_type
       end
 
       # Returns type
@@ -80,7 +81,7 @@ module StoreModel
       end
 
       def cast_model_type_value(value)
-        @model_klass.to_type.cast_value(value)
+        @model_klass_type.cast_value(value)
       end
     end
   end

--- a/spec/store_model/types/array_type_spec.rb
+++ b/spec/store_model/types/array_type_spec.rb
@@ -78,6 +78,51 @@ RSpec.describe StoreModel::Types::ArrayType do
         )
       end
     end
+
+    context "when some keys are not defined as attributes" do
+      shared_examples "for unknown attributes" do
+        it { is_expected.to be_a(Array) }
+
+        it "assigns attributes" do
+          expect(subject.first).to have_attributes(color: "red")
+          expect(subject.second).to have_attributes(color: "green")
+        end
+
+        it "assigns unknown_attributes" do
+          expect(subject.first.unknown_attributes).to eq(
+            "unknown_attribute" => "something", "one_more" => "anything"
+          )
+          expect(subject.second.unknown_attributes).to eq(
+            "unknown_attribute" => "something greeny", "one_more" => "anything greeny"
+          )
+        end
+      end
+
+      let(:attributes_array) do
+        [
+          {
+            color: "red",
+            unknown_attribute: "something",
+            one_more: "anything"
+          },
+          {
+            color: "green",
+            unknown_attribute: "something greeny",
+            one_more: "anything greeny"
+          }
+        ]
+      end
+
+      context "when Hash is passed" do
+        let(:value) { attributes_array }
+        include_examples "for unknown attributes"
+      end
+
+      context "when String is passed" do
+        let(:value) { ActiveSupport::JSON.encode(attributes_array) }
+        include_examples "for unknown attributes"
+      end
+    end
   end
 
   describe "#serialize" do


### PR DESCRIPTION
An attempt to resolve this issue: #32 

The simple solution is to use ArrayType as wrapper around its @model_klass and delegate type casting to it
I just made a quick look and fix, I'm not sure is there any caveats 🤔 