### PR TITLE
Update unknown_attributes doc

### DIFF
--- a/docs/unknown_attributes.md
+++ b/docs/unknown_attributes.md
@@ -9,6 +9,12 @@ class Configuration
   attribute :color, :string
 end
 
-configuration = Configuration.new(color: "red", archived: true)
+configuration = Configuration.to_type.cast_value(color: "red", archived: true)
 configuration.unknown_attributes # => { "archived" => true }
+
+# OR
+
+configurations = Configuration.to_array_type.cast_value( [{ color: "red", archived: true }, [{ color: "blue", archived: false }])
+configurations.map { |config| config.unknown_attributes } # => [{ "archived" => true }, { "archived" => false }]
+
 ```


### PR DESCRIPTION
Describe correct way to initialize store model instance with wrong attributes
___________________
```Ruby
Configuration.new(color: "red", archived: true)
```
Usage `new` calls constructor from `ActiveModel::Model` which simply assigns attributes and we end up with `ActiveModel::UnknownAttributeError`

In this case first we need to build type and then call `cast_value`