### PR TITLE
Fix inspect output for falsey values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## master
 
-## 0.5.4 (2019-09-17)
-
-- [PR #38](https://github.com/DmitryTsepelev/store_model/pull/38) Fix inspect output for false values ([@zokioki][])
+- [PR #38](https://github.com/DmitryTsepelev/store_model/pull/38) Fix inspect output for false values ([@zokioki](https://github.com/zokioki))
 
 ## 0.5.3 (2019-09-05)
 
@@ -61,5 +59,5 @@
 
 - Initial version ([@DmitryTsepelev][])
 
-[@dmitrytsepelev]: https://github.com/DmitryTsepelev
+[@DmitryTsepelev]: https://github.com/DmitryTsepelev
 [@iarie]: https://github.com/iarie

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## 0.5.4 (2019-09-17)
+
+- [PR #38](https://github.com/DmitryTsepelev/store_model/pull/38) Fix inspect output for false values ([@zokioki][])
+
 ## 0.5.3 (2019-09-05)
 
 - [PR #34](https://github.com/DmitryTsepelev/store_model/pull/34) Fix `#unknown_attributes` assignment for `ArrayType` ([@iarie][])
@@ -57,5 +61,5 @@
 
 - Initial version ([@DmitryTsepelev][])
 
-[@DmitryTsepelev]: https://github.com/DmitryTsepelev
+[@dmitrytsepelev]: https://github.com/DmitryTsepelev
 [@iarie]: https://github.com/iarie

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -49,7 +49,7 @@ module StoreModel
     #
     # @return [String]
     def inspect
-      attribute_string = attributes.map { |name, value| "#{name}: #{value || 'nil'}" }.join(", ")
+      attribute_string = attributes.map { |name, value| "#{name}: #{value.inspect}" }.join(", ")
       "#<#{self.class.name} #{attribute_string}>"
     end
 

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -49,7 +49,8 @@ module StoreModel
     #
     # @return [String]
     def inspect
-      attribute_string = attributes.map { |name, value| "#{name}: #{value.nil? ? 'nil' : value}" }.join(", ")
+      attribute_string = attributes.map { |name, value| "#{name}: #{value.nil? ? 'nil' : value}" }
+                                   .join(", ")
       "#<#{self.class.name} #{attribute_string}>"
     end
 

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -49,7 +49,7 @@ module StoreModel
     #
     # @return [String]
     def inspect
-      attribute_string = attributes.map { |name, value| "#{name}: #{value.inspect}" }.join(", ")
+      attribute_string = attributes.map { |name, value| "#{name}: #{value.nil? ? 'nil' : value}" }.join(", ")
       "#<#{self.class.name} #{attribute_string}>"
     end
 

--- a/lib/store_model/version.rb
+++ b/lib/store_model/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StoreModel # :nodoc:
-  VERSION = "0.5.3"
+  VERSION = "0.5.4"
 end

--- a/lib/store_model/version.rb
+++ b/lib/store_model/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StoreModel # :nodoc:
-  VERSION = "0.5.4"
+  VERSION = "0.5.3"
 end

--- a/spec/dummy/app/models/configuration.rb
+++ b/spec/dummy/app/models/configuration.rb
@@ -4,6 +4,8 @@ class Configuration
   include StoreModel::Model
 
   attribute :color, :string
+  attribute :model, :string
+  attribute :active, :boolean
   attribute :disabled_at, :datetime
 
   validates :color, presence: true

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe StoreModel::Model do
 
     it "prints description" do
       expect(subject).to eq(
-        "#<Configuration color: red, model: nil, active: false, disabled_at: #{attributes[:disabled_at]}>"
+        "#<Configuration color: red, model: nil, active: false, " \
+        "disabled_at: #{attributes[:disabled_at]}>"
       )
     end
   end

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -4,7 +4,12 @@ require "spec_helper"
 
 RSpec.describe StoreModel::Model do
   let(:attributes) do
-    { color: "red", disabled_at: Time.new(2019, 2, 10, 12) }
+    {
+      color: "red",
+      model: nil,
+      active: false,
+      disabled_at: Time.new(2019, 2, 10, 12)
+    }
   end
 
   describe "#initialize" do
@@ -46,7 +51,7 @@ RSpec.describe StoreModel::Model do
 
     it "prints description" do
       expect(subject).to eq(
-        "#<Configuration color: red, disabled_at: #{attributes[:disabled_at]}>"
+        "#<Configuration color: red, model: nil, active: false, disabled_at: #{attributes[:disabled_at]}>"
       )
     end
   end

--- a/spec/store_model/types/json_type_spec.rb
+++ b/spec/store_model/types/json_type_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe StoreModel::Types::JsonType do
   let(:attributes) do
     {
       color: "red",
+      model: nil,
+      active: false,
       disabled_at: Time.new(2019, 2, 22, 12, 30)
     }
   end


### PR DESCRIPTION
This change ensures that falsey values are reflected correctly when printing
out the final result - they currently print out as `nil`. For example:

```ruby
class MyStoreModel < StoreModel
  attribute :one, :integer, default: 1
  attribute :two, :boolean, default: false
  attribute :three, :string, default: nil
end
```

Current Behavior: `<MyStoreModel one: 1, two: nil, three: nil>`
Expected Behavior:  `<MyStoreModel one: 1, two: false, three: nil>`