### PR TITLE
Depend on activerecord only in the gemspec

### DIFF
--- a/store_model.gemspec
+++ b/store_model.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3"
 
-  spec.add_dependency "rails", ">= 5.2"
+  spec.add_dependency "activerecord", ">= 5.2"
 
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-rails"


### PR DESCRIPTION
Hey @DmitryTsepelev, thanks for making a great library. It was pretty much exactly what I was looking for :)

I added it to my Rails app but noticed it depends on all of rails, and not just active record. My app doesn't use all of Rails (most of it, but not Active Storage), and I don't want that dependency if I can avoid it.

Is this change ok?