### PR TITLE
Fix syntax errors in code blocks in documentation

### DIFF
--- a/docs/enums.md
+++ b/docs/enums.md
@@ -10,7 +10,7 @@ class Configuration
 end
 
 config = Configuration.new
-config.status => # active
+config.status # => active
 
 config.status = :archived
 config.archived? # => true

--- a/docs/unknown_attributes.md
+++ b/docs/unknown_attributes.md
@@ -14,7 +14,7 @@ configuration.unknown_attributes # => { "archived" => true }
 
 # OR
 
-configurations = Configuration.to_array_type.cast_value( [{ color: "red", archived: true }, [{ color: "blue", archived: false }])
+configurations = Configuration.to_array_type.cast_value([{ color: "red", archived: true }, { color: "blue", archived: false }])
 configurations.map { |config| config.unknown_attributes } # => [{ "archived" => true }, { "archived" => false }]
 
 ```

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -61,7 +61,7 @@ StoreModel.config.merge_errors = true
 You can also add your own custom strategies to handle errors. All you need to do is to provide a callable object to `StoreModel.config.merge_errors` or as value of `:merge_errors`. It should accept three arguments–_attribute_, _base_errors_ and _store_model_errors_:
 
 ```ruby
-StoreModel.config.merge_errors = lambda do |attribute, base_errors, _store_model_errors| do
+StoreModel.config.merge_errors = lambda do |attribute, base_errors, _store_model_errors|
   base_errors.add(attribute, "cthulhu fhtagn")
 end
 ```


### PR DESCRIPTION
Thank you for creating this great gem! I noticed a few syntax errors in documentation. Please review my pull request. Thanks!