### PR TITLE
Validate all elements of ArrayType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,3 +71,4 @@
 [@blaze182]: https://github.com/blaze182
 [@zokioki]: https://github.com/zokioki
 [@keithpitt]: https://github.com/keithpitt
+[@bostanio]: https://github.com/bostanio

--- a/lib/active_model/validations/store_model_validator.rb
+++ b/lib/active_model/validations/store_model_validator.rb
@@ -24,7 +24,7 @@ module ActiveModel
         when :json
           strategy.call(attribute, record.errors, value.errors) if value.invalid?
         when :array
-          record.errors.add(attribute, :invalid) if value.any?(&:invalid?)
+          record.errors.add(attribute, :invalid) if value.select(&:invalid?).present?
         end
       end
 

--- a/spec/active_model/validations/store_model_validator_spec.rb
+++ b/spec/active_model/validations/store_model_validator_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe ActiveModel::Validations::StoreModelValidator do
       end
 
       context "when array member is invalid" do
-        let(:attributes) { { configuration: [Configuration.new] } }
+        let(:attributes) { { configuration: [Configuration.new, Configuration.new] } }
 
         it { is_expected.to be_invalid }
 
@@ -94,6 +94,9 @@ RSpec.describe ActiveModel::Validations::StoreModelValidator do
 
           expect(subject.configuration.first.errors.messages).to eq(color: ["can't be blank"])
           expect(subject.configuration.first.errors.full_messages).to eq(["Color can't be blank"])
+
+          expect(subject.configuration.second.errors.messages).to eq(color: ["can't be blank"])
+          expect(subject.configuration.second.errors.full_messages).to eq(["Color can't be blank"])
         end
       end
 


### PR DESCRIPTION
The previous implementation used `any?` to validate ArrayType. That has the effect elements after the first invalid element don't get validated and their errors collection isn't populated.

This fix makes sure to call `invalid?` on every element of the array before setting an error on the parent record.