### PR TITLE
coder type option

### DIFF
--- a/lib/store_model/coders/case.rb
+++ b/lib/store_model/coders/case.rb
@@ -1,0 +1,27 @@
+module StoreModel
+  module Coders
+    class Case
+      class << self
+        def [](type)
+          type.to_s.classify.constantize
+        end
+
+        def dump(attributes)
+          attributes.transform_keys(&method(:transform_key))
+        end
+
+        def load(hash)
+          hash.transform_keys(&:underscore)
+        end
+      end
+
+      class Camel < self
+        class << self
+          def transform_key(key)
+            key.camelize(:lower)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/store_model/coders/null.rb
+++ b/lib/store_model/coders/null.rb
@@ -1,0 +1,15 @@
+module StoreModel
+  module Coders
+    module Null
+      class << self
+        def dump(attributes)
+          attributes
+        end
+
+        def load(hash)
+          hash
+        end
+      end
+    end
+  end
+end

--- a/lib/store_model/configuration.rb
+++ b/lib/store_model/configuration.rb
@@ -10,5 +10,7 @@ module StoreModel
     # Controls usage of MergeArrayErrorStrategy
     # @return [Boolean]
     attr_accessor :merge_array_errors
+
+    attr_accessor :type_options
   end
 end

--- a/lib/store_model/type_builders.rb
+++ b/lib/store_model/type_builders.rb
@@ -6,13 +6,23 @@ module StoreModel
     # Converts StoreModel::Model to Types::JsonType
     # @return [Types::JsonType]
     def to_type
-      Types::JsonType.new(self)
+      coder = @type_options[:coder]
+      coder ||= @type_options[:case] && Coders::Case[@type_options[:case]]
+      coder ||= Coders::Null
+
+      Types::JsonType.new(self, coder)
     end
 
     # Converts StoreModel::Model to Types::ArrayType
     # @return [Types::ArrayType]
     def to_array_type
       Types::ArrayType.new(self)
+    end
+
+    def type_options(options = {})
+      @type_options ||= StoreModel.config.type_options
+      @type_options.merge!(options)
+      @type_options
     end
   end
 end


### PR DESCRIPTION
@DmitryTsepelev I am working with legacy data where the json is unfortunately `camelCased`. Before I do more work on this PR, I was wondering if you think this is a good idea. The gist is that in the flow from `json -> hash -> attributes -> model`, my use case requires the ability to choose a different way to do `hash -> attributes`. I have opened up a place to perform this transformation (previously only `json -> hash -> model` was possible) and invented the idea of a custom way to do it which I've called a coder (perhaps too ambiguous, maybe `attributes_coder`?). The coder can be specified at the class level for a class that has included `StoreModel::Model` and there are also some premade ones to transform case.

I noticed that this decouples the serialization from `as_json`, and perhaps this is a good thing, I'm not sure.

Also I have not run this code at all, so there's a chance the whole idea is flawed, but I doubt it somewhat.