### PR TITLE
Add #to_yaml method to StoreModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR #86](https://github.com/DmitryTsepelev/store_model/pull/86) Add #to_yaml method to StoreModel ([@DmitryTsepelev]())
+
 ## 0.8.1 (2021-01-25)
 
 - [PR #79](https://github.com/DmitryTsepelev/store_model/pull/79) Fix infinite loop with nested model and :attributes key ([@timhwang21]())

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -29,6 +29,13 @@ module StoreModel
       attributes.with_indifferent_access.as_json(options)
     end
 
+    # Returns a YAML representing the model.
+    #
+    # @return [String]
+    def to_yaml
+      attributes.to_yaml
+    end
+
     # Compares two StoreModel::Model instances
     #
     # @param other [StoreModel::Model]

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe StoreModel::Model do
     end
   end
 
+  describe "#to_yaml" do
+    let(:instance) { Configuration.new(attributes) }
+
+    subject { instance.to_yaml }
+
+    it("returns YAML of the hash") { is_expected.to eq(instance.attributes.to_yaml) }
+  end
+
   describe "#blank?" do
     subject { Configuration.new(color: nil).blank? }
 


### PR DESCRIPTION
Refs #82

audited uses yaml to serialize data, and this change makes it think that it works with a regular hash