### PR TITLE
Handle aliases with has_attributes

### DIFF
--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -70,6 +70,18 @@ module StoreModel
 
     # Checks if the attribute with a given name is defined
     #
+    # @example
+    #    class Person
+    #      include StoreModel::Model
+    #      attribute :name, :string
+    #      alias_attribute :new_name, :name
+    #    end
+    #
+    #    Person.has_attribute?('name')     # => true
+    #    Person.has_attribute?('new_name') # => true
+    #    Person.has_attribute?(:age)       # => true
+    #    Person.has_attribute?(:nothing)   # => false
+    #
     # @param attr_name [String] name of the attribute
     #
     # @return [Boolean]
@@ -79,6 +91,16 @@ module StoreModel
       attr_name = self.class.attribute_aliases[attr_name] || attr_name
       attribute_types.key?(attr_name)
     end
+
+    # Legacy implementation of #has_attribute?
+    #
+    # @param attr_name [String] name of the attribute
+    #
+    # @return [Boolean]
+    def _has_attribute?(attr_name)
+      attribute_types.key?(attr_name)
+    end
+
     # rubocop:enable Naming/PredicateName
 
     # Contains a hash of attributes which are not defined but exist in the

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -75,7 +75,9 @@ module StoreModel
     # @return [Boolean]
     # rubocop:disable Naming/PredicateName
     def has_attribute?(attr_name)
-      attribute_types.key?(attr_name.to_s)
+      attr_name = attr_name.to_s
+      attr_name = self.class.attribute_aliases[attr_name] || attr_name
+      attribute_types.key?(attr_name)
     end
     # rubocop:enable Naming/PredicateName
 

--- a/spec/dummy/app/models/configuration.rb
+++ b/spec/dummy/app/models/configuration.rb
@@ -8,5 +8,7 @@ class Configuration
   attribute :active, :boolean
   attribute :disabled_at, :datetime
 
+  alias_attribute :enabled, :active
+
   validates :color, presence: true
 end

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe StoreModel::Model do
     end
 
     context "when alias attribute is passed" do
-      let(:attribute) {:enabled}
+      let(:attribute) { :enabled }
 
       it { is_expected.to be_truthy }
     end

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -226,5 +226,11 @@ RSpec.describe StoreModel::Model do
 
       it { is_expected.to be_falsey }
     end
+
+    context "when alias attribute is passed" do
+      let(:attribute) {:enabled}
+
+      it { is_expected.to be_truthy }
+    end
   end
 end


### PR DESCRIPTION
Change `StoreModel::Model#has_attribute?` to respond `true` on aliased attributes.

The same changes were made on Rails 6.1 : 
* https://github.com/rails/rails/blob/6-1-stable/activerecord/lib/active_record/attribute_methods.rb#L170-L189
* https://github.com/rails/rails/commit/c53c418e6f1ac5297bdec9851b87f3a345be069d