### PR TITLE
Add predicate methods (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR #97](https://github.com/DmitryTsepelev/store_model/pull/97) Add predicate methods ([@f-mer])
+
 ## 0.9.0 (2021-04-21)
 
 - [PR #93](https://github.com/DmitryTsepelev/store_model/pull/93) Handle aliases with has_attributes ([@Zooip]
@@ -99,3 +101,4 @@
 [@bostanio]: https://github.com/bostanio
 [@timhwang21]: https://github.com/timhwang21
 [@Zooip]: https://github.com/Zooip
+[@f-mer]: https://github.com/f-mer

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -120,8 +120,7 @@ module StoreModel
       case value = attributes[attribute]
       when true then true
       when false, nil, 0 then false
-      else
-        value.present?
+      else value.present?
       end
     end
   end

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -118,8 +118,7 @@ module StoreModel
 
     def attribute?(attribute)
       case value = attributes[attribute]
-      when true then true
-      when false, nil, 0 then false
+      when 0 then false
       else value.present?
       end
     end

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -11,10 +11,13 @@ module StoreModel
     def self.included(base) # :nodoc:
       base.include ActiveModel::Model
       base.include ActiveModel::Attributes
+      base.include ActiveModel::AttributeMethods
       base.include StoreModel::NestedAttributes
 
       base.extend StoreModel::Enum
       base.extend StoreModel::TypeBuilders
+
+      base.attribute_method_suffix "?"
     end
 
     attr_accessor :parent
@@ -109,6 +112,17 @@ module StoreModel
     # @return [Hash]
     def unknown_attributes
       @unknown_attributes ||= {}
+    end
+
+    private
+
+    def attribute?(attribute)
+      case value = attributes[attribute]
+      when true then true
+      when false, nil, 0 then false
+      else
+        value.present?
+      end
     end
   end
 end

--- a/spec/dummy/app/models/bicycle.rb
+++ b/spec/dummy/app/models/bicycle.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Bicycle
+  include StoreModel::Model
+
+  attribute :gears, :integer
+end

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -233,4 +233,76 @@ RSpec.describe StoreModel::Model do
       it { is_expected.to be_truthy }
     end
   end
+
+  describe "predicate method for string attribute" do
+    subject { Configuration.new(color: value).color? }
+
+    context "when value is present" do
+      let(:value) { "red" }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when value is nil" do
+      let(:value) { nil }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when value is blank" do
+      let(:value) { "" }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when value is \" \"" do
+      let(:value) { " " }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  describe "predicate method for number attribute" do
+    subject { Bicycle.new(gears: value).gears? }
+
+    context "when value is 1" do
+      let(:value) { 1 }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when value is nil" do
+      let(:value) { nil }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when value is 0" do
+      let(:value) { 0 }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  describe "predicate method for boolean attribute" do
+    subject { Configuration.new(active: value).active? }
+
+    context "when value is true" do
+      let(:value) { true }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when value is nil" do
+      let(:value) { nil }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when value is false" do
+      let(:value) { false }
+
+      it { is_expected.to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
This PR adds predicate methods as suggested in #89. 

It is loosely modeled after the [implementation in rails](https://github.com/rails/rails/blob/56d8ff83726bb6c0b1f570deb057835f90a75e30/activerecord/lib/active_record/attribute_methods/query.rb). 
I'm not 100% sure about the `method_missing` based implementation but at least that is how rails does it. Any thoughts?