### PR TITLE
Add hash method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,19 @@
 
 ## master
 
+- [PR #99](https://github.com/DmitryTsepelev/store_model/pull/99) Add `#hash` method ([@skryukov])
+
 ## 0.10.0 (2021-07-06)
 
 - [PR #97](https://github.com/DmitryTsepelev/store_model/pull/97) Add predicate methods ([@f-mer])
 
 ## 0.9.0 (2021-04-21)
 
-- [PR #93](https://github.com/DmitryTsepelev/store_model/pull/93) Handle aliases with has_attributes ([@Zooip]
+- [PR #93](https://github.com/DmitryTsepelev/store_model/pull/93) Handle aliases with has_attributes ([@Zooip])
 
 ## 0.8.2 (2021-02-10)
 
-- [PR #88](https://github.com/DmitryTsepelev/store_model/pull/88) Avoid overriding parent validation messages when child is invalid ([@DmitryTsepelev]
+- [PR #88](https://github.com/DmitryTsepelev/store_model/pull/88) Avoid overriding parent validation messages when child is invalid ([@DmitryTsepelev])
 
 ## 0.8.1 (2021-01-25)
 
@@ -104,3 +106,4 @@
 [@timhwang21]: https://github.com/timhwang21
 [@Zooip]: https://github.com/Zooip
 [@f-mer]: https://github.com/f-mer
+[@skryukov]: https://github.com/skryukov

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -43,6 +43,13 @@ module StoreModel
       attributes.all? { |name, value| value == other.attributes[name] }
     end
 
+    # Returns hash for a StoreModel::Model instance based on attributes hash
+    #
+    # @return [Integer]
+    def hash
+      attributes.hash
+    end
+
     # Allows to call :presence validation on the association itself.
     #
     # @return [Boolean]

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -137,6 +137,50 @@ RSpec.describe StoreModel::Model do
     end
   end
 
+  describe "hash" do
+    let(:first_setting) { Configuration.new(color: "red") }
+
+    subject { first_setting.hash == second_setting.hash }
+
+    context "when two instances have same attributes" do
+      let(:second_setting) { Configuration.new(color: "red") }
+
+      it { is_expected.to be true }
+    end
+
+    context "when two instances have different attributes" do
+      let(:second_setting) { Configuration.new(color: "black") }
+
+      it { is_expected.to be false }
+    end
+
+    context "when StoreModel has enum attribute" do
+      let(:config_class) do
+        Class.new do
+          include StoreModel::Model
+
+          enum :status, in: { active: 1, archived: 0 }
+        end
+      end
+
+      let(:first_setting) { config_class.new(status: :active) }
+
+      subject { first_setting.hash == second_setting.hash }
+
+      context "when two instances have same attributes" do
+        let(:second_setting) { config_class.new(status: :active) }
+
+        it { is_expected.to be true }
+      end
+
+      context "when two instances have different attributes" do
+        let(:second_setting) { config_class.new(status: :archived) }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+
   describe "==" do
     let(:first_setting) { Configuration.new(color: "red") }
 


### PR DESCRIPTION
This PR introduces `#hash` method for StoreModel::Model instance based on attributes hash.
This going to unlock using rspec matchers for example:

```ruby
expect { subject }.not_to change { settings.reload.configuration }
```