### PR TITLE
Don't load railtie if there is no rails

### DIFF
--- a/lib/store_model.rb
+++ b/lib/store_model.rb
@@ -2,7 +2,7 @@
 
 require "store_model/model"
 require "store_model/configuration"
-require "store_model/railtie"
+require "store_model/railtie" if defined?(::Rails::Railtie)
 require "active_model/validations/store_model_validator"
 
 module StoreModel # :nodoc:


### PR DESCRIPTION
Using store_model without rails was also discussed in #71. Trying to
load the railtie would raise an error in that case.