### PR TITLE
Add support for enum affixes

### DIFF
--- a/docs/enums.md
+++ b/docs/enums.md
@@ -35,3 +35,26 @@ class Review
   enum :rating, in: { excellent: 100, okay: 50, bad: 25, awful: 10 }, default: :okay
 end
 ```
+
+You can use the `:_prefix` or `:_suffix` options when you need to define multiple enums with same values. If the passed value is true, the methods are prefixed/suffixed with the name of the enum. It is also possible to supply a custom value:
+
+```ruby
+class Review
+  include StoreModel::Model
+
+  enum status: [:active, :archived], _suffix: true
+  enum comments_status: [:active, :inactive], _prefix: :comments
+end
+```
+With the above example, the predicate methods are now prefixed and/or suffixed accordingly:
+
+```ruby
+review = Review.new(status: :active, comment_status: :inactive)
+
+review.active_status? # => true
+review.archived_status? # => false
+
+review.comments_active? # => false
+review.comments_inactive? # => true
+
+```

--- a/spec/store_model/enum_spec.rb
+++ b/spec/store_model/enum_spec.rb
@@ -108,6 +108,48 @@ RSpec.describe StoreModel::Model do
     end
   end
 
+  context "when multiple enum with prefix is provided" do
+    let(:config_class) do
+      Class.new do
+        include StoreModel::Model
+
+        enum :status, %i[active archived], _prefix: true
+        enum :comment_status, %i[active archived], _prefix: "comment"
+      end
+    end
+
+    subject { config_class.new(status: :active, comment_status: :archived) }
+
+    it "has prefixed predicate methods" do
+      expect(subject).to be_status_active
+      expect(subject).not_to be_status_archived
+
+      expect(subject).to be_comment_archived
+      expect(subject).not_to be_comment_active
+    end
+  end
+
+  context "when multiple enum with suffix is provided" do
+    let(:config_class) do
+      Class.new do
+        include StoreModel::Model
+
+        enum :status, %i[active archived], _suffix: true
+        enum :comment_status, %i[active archived], _suffix: "comment"
+      end
+    end
+
+    subject { config_class.new(status: :active, comment_status: :archived) }
+
+    it "has suffixed predicate methods" do
+      expect(subject).to be_active_status
+      expect(subject).not_to be_archived_status
+
+      expect(subject).to be_archived_comment
+      expect(subject).not_to be_active_comment
+    end
+  end
+
   describe "#valid?" do
     let(:config_class) do
       Class.new do


### PR DESCRIPTION
Adds support for `_prefix` and `_suffix` options to enum types, similar to `ActiveRecord::Enum`