### PR TITLE
Fix validation for cast attributes

### DIFF
--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -11,6 +11,7 @@ module StoreModel
     def self.included(base) # :nodoc:
       base.include ActiveModel::Model
       base.include ActiveModel::Attributes
+      base.include ActiveRecord::AttributeMethods::BeforeTypeCast
       base.include ActiveModel::AttributeMethods
       base.include StoreModel::NestedAttributes
 

--- a/spec/store_model/cast_validation_spec.rb
+++ b/spec/store_model/cast_validation_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+class ExampleModel
+  include StoreModel::Model
+
+  attribute :amount, :float
+
+  validates :amount, numericality: { greater_than_or_equal_to: 0 }
+end
+
+RSpec.describe StoreModel::Model do
+  subject { ExampleModel.new(amount: amount) }
+
+  context "when attribute is cast from an invalid value" do
+    let(:amount) { "junk" }
+
+    it { is_expected.to be_invalid }
+  end
+
+  context "when attribute is cast from a valid value" do
+    let(:amount) { "20" }
+
+    it { is_expected.to be_valid }
+  end
+end


### PR DESCRIPTION
# Problem

For attributes that have a cast type provided the validation was performed using the cast value and not the raw value. This is problematic in the case of a float attribute that can be greater than or equal to 0. 

```
include StoreModel::Model

attribute :amount, :float

validates :amount, numericality: { greater_than_or_equal_to: 0 }
```

When a bad value is passed to the float attribute i.e "junk" it is cast to 0.0 which passes the numericality check. 

# Solution

Including the [ActiveRecord::AttributeMethods::BeforeTypeCast](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/BeforeTypeCast.html) module allows the raw value to be validated. 

[numericality](https://github.com/rails/rails/blob/7-0-stable/activemodel/lib/active_model/validations/numericality.rb#L123-L142) accessing the raw value.