### PR TITLE
Quote 3.0 in the CI configuration

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [jruby, 2.6, 2.7, 3.0, 3.1]
+        ruby: [jruby, 2.6, 2.7, "3.0", 3.1]
 
         gemfile: [
           "gemfiles/jruby.gemfile",
@@ -46,7 +46,7 @@ jobs:
             gemfile: gemfiles/jruby.gemfile
           - ruby: 2.7
             gemfile: gemfiles/jruby.gemfile
-          - ruby: 3.0
+          - ruby: "3.0"
             gemfile: gemfiles/jruby.gemfile
           - ruby: 3.1
             gemfile: gemfiles/jruby.gemfile


### PR DESCRIPTION
An unquoted 3.0 is truncated to a 3, leading to the latest Ruby 3 version being loaded.  At this time that's a Ruby 3.1.x version, which is not what's intended.

Quoting the 3.0 ensures that a 3.0.x version is loaded for these lines in CI.