### PR TITLE
Replaces `&method` call to fix parent assignment when the model has a `method` attribute. Fixes #121

### DIFF
--- a/lib/store_model/ext/parent_assignment.rb
+++ b/lib/store_model/ext/parent_assignment.rb
@@ -9,7 +9,9 @@ module StoreModel
       assign_parent_to_singular_store_model(attribute)
       return unless attribute.is_a?(Array)
 
-      attribute.each(&method(:assign_parent_to_singular_store_model))
+      # Do not use &method here or it will break if the model has a method attribute
+      # See https://github.com/DmitryTsepelev/store_model/issues/121
+      attribute.each { |a| assign_parent_to_singular_store_model(a) }
     end
 
     def assign_parent_to_singular_store_model(item)

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -3,7 +3,7 @@
 ActiveRecord::Schema.define(version: 2019_02_216_153105) do
   create_table :products do |t|
     t.string :name
-    t.string :method
+    t.string :method # Reproduces #121: https://github.com/DmitryTsepelev/store_model/issues/121
     t.json :configuration, default: {}
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -3,6 +3,7 @@
 ActiveRecord::Schema.define(version: 2019_02_216_153105) do
   create_table :products do |t|
     t.string :name
+    t.string :method
     t.json :configuration, default: {}
   end
 end


### PR DESCRIPTION
@DmitryTsepelev this reproduces the bug from https://github.com/DmitryTsepelev/store_model/issues/121

I can confirm that just changing this: https://github.com/DmitryTsepelev/store_model/blob/26b3ac0cc748e3d6378ef9e1e97b729330faa49d/lib/store_model/ext/parent_assignment.rb#L12

To this to solves the issue:
```ruby
attribute.each do { |a| assign_parent_to_singular_store_model(a) }
```

I don't know if just adding this is enough, please, let me know if we have an idea how to write a specific spec for this.