### PR TITLE
Add config option `serialize_unknown_attributes`

### DIFF
--- a/docs/unknown_attributes.md
+++ b/docs/unknown_attributes.md
@@ -18,3 +18,32 @@ configurations = Configuration.to_array_type.cast_value([{ color: "red", archive
 configurations.map { |config| config.unknown_attributes } # => [{ "archived" => true }, { "archived" => false }]
 
 ```
+
+## Serialization of unknown attributes
+
+By default `StoreModel` will serialize unknown attributes when you call `as_json` on an instance.
+
+```ruby
+configuration = Configuration.to_type.cast_value(color: "red", archived: true)
+configuration.as_json # => {"color": "red", "archived": true}
+```
+
+You can change that behavior globally by turning off serialization for unknown attributes.
+
+```ruby
+StoreModel.config.serialize_unknown_attributes = false
+
+configuration = Configuration.to_type.cast_value(color: "red", archived: true)
+configuration.as_json # => {"color": "red"}
+```
+
+You can always pass the `serialize_unknown_attributes` option to the `as_json` method to override the globally configured behavior.
+
+```ruby
+StoreModel.config.serialize_unknown_attributes = false
+
+configuration = Configuration.to_type.cast_value(color: "red", archived: true)
+configuration.as_json # => {"color": "red", "archived": true}
+```
+
+In any case unknown attributes are always stored in the database.

--- a/lib/store_model/configuration.rb
+++ b/lib/store_model/configuration.rb
@@ -10,5 +10,13 @@ module StoreModel
     # Controls usage of MergeArrayErrorStrategy
     # @return [Boolean]
     attr_accessor :merge_array_errors
+
+    # Controls if the result of `as_json` will contain the unknown attributes of the model
+    # @return [Boolean]
+    attr_accessor :serialize_unknown_attributes
+
+    def initialize
+      @serialize_unknown_attributes = true
+    end
   end
 end

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -30,7 +30,15 @@ module StoreModel
     #
     # @return [Hash]
     def as_json(options = {})
-      attributes.with_indifferent_access.merge(unknown_attributes).as_json(options)
+      serialize_unknown_attributes = if options.key?(:serialize_unknown_attributes)
+                                       options[:serialize_unknown_attributes]
+                                     else
+                                       StoreModel.config.serialize_unknown_attributes
+                                     end
+
+      result = attributes.with_indifferent_access
+      result.merge!(unknown_attributes) if serialize_unknown_attributes
+      result.as_json(options)
     end
 
     # Compares two StoreModel::Model instances

--- a/lib/store_model/types/many_base.rb
+++ b/lib/store_model/types/many_base.rb
@@ -38,7 +38,7 @@ module StoreModel
       def serialize(value)
         case value
         when Array
-          ActiveSupport::JSON.encode(value)
+          ActiveSupport::JSON.encode(value, serialize_unknown_attributes: true)
         else
           super
         end

--- a/lib/store_model/types/one.rb
+++ b/lib/store_model/types/one.rb
@@ -47,7 +47,7 @@ module StoreModel
       def serialize(value)
         case value
         when Hash, @model_klass
-          ActiveSupport::JSON.encode(value)
+          ActiveSupport::JSON.encode(value, serialize_unknown_attributes: true)
         else
           super
         end

--- a/lib/store_model/types/one_polymorphic.rb
+++ b/lib/store_model/types/one_polymorphic.rb
@@ -52,9 +52,11 @@ module StoreModel
       def serialize(value)
         case value
         when Hash
-          ActiveSupport::JSON.encode(value)
+          ActiveSupport::JSON.encode(value, serialize_unknown_attributes: true)
         else
-          return ActiveSupport::JSON.encode(value) if implements_model?(value.class)
+          if implements_model?(value.class)
+            return ActiveSupport::JSON.encode(value, serialize_unknown_attributes: true)
+          end
 
           super
         end

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -38,6 +38,67 @@ RSpec.describe StoreModel::Model do
 
       it("returns correct JSON") { is_expected.to eq(attributes.slice(:color).as_json) }
     end
+
+    context "with unknown attributes" do
+      let(:type) { StoreModel::Types::One.new(Configuration) }
+      let(:instance) { type.cast_value(attributes.merge(unknown_attributes)) }
+
+      let(:unknown_attributes) do
+        {
+          archived: true
+        }
+      end
+
+      shared_examples "with unknown attributes" do
+        it("returns correct JSON") do
+          is_expected.to eq(attributes.merge(unknown_attributes).as_json)
+        end
+      end
+
+      shared_examples "without unknown attributes" do
+        it("returns correct JSON") { is_expected.to eq(attributes.as_json) }
+      end
+
+      context "with default config about unknown attributes serialization" do
+        include_examples "with unknown attributes"
+      end
+
+      context "with config set to serialize unknown attributes" do
+        before do
+          StoreModel.config.serialize_unknown_attributes = true
+        end
+
+        include_examples "with unknown attributes"
+      end
+
+      context "with config set not to serialize unknown attributes" do
+        before do
+          StoreModel.config.serialize_unknown_attributes = false
+        end
+
+        include_examples "without unknown attributes"
+      end
+
+      context "with config set to serialize unknown attributes overridden by option" do
+        before do
+          StoreModel.config.serialize_unknown_attributes = true
+        end
+
+        subject { instance.as_json(serialize_unknown_attributes: false) }
+
+        include_examples "without unknown attributes"
+      end
+
+      context "with config set not to serialize unknown attributes overridden by option" do
+        before do
+          StoreModel.config.serialize_unknown_attributes = false
+        end
+
+        subject { instance.as_json(serialize_unknown_attributes: true) }
+
+        include_examples "with unknown attributes"
+      end
+    end
   end
 
   describe "#blank?" do

--- a/spec/store_model/types/many_spec.rb
+++ b/spec/store_model/types/many_spec.rb
@@ -122,6 +122,24 @@ RSpec.describe StoreModel::Types::Many do
         let(:value) { ActiveSupport::JSON.encode(attributes_array) }
         include_examples "for unknown attributes"
       end
+
+      context "when saving model" do
+        subject { persisted_product.configurations }
+
+        let(:custom_product_class) do
+          build_custom_product_class do
+            attribute :configurations, Configuration.to_array_type
+          end
+        end
+
+        let(:persisted_product) do
+          custom_product_class.create(
+            configurations: Configuration.to_array_type.cast_value(attributes_array)
+          )
+        end
+
+        include_examples "for unknown attributes"
+      end
     end
   end
 

--- a/spec/store_model/types/one_polymorphic_spec.rb
+++ b/spec/store_model/types/one_polymorphic_spec.rb
@@ -120,6 +120,24 @@ RSpec.describe StoreModel::Types::OnePolymorphic do
         include_examples "for unknown attributes"
       end
 
+      context "when saving model" do
+        subject { persisted_product.configuration }
+
+        let(:custom_product_class) do
+          build_custom_product_class do
+            attribute :configuration, StoreModel::Types::OnePolymorphic.new(proc { Configuration })
+          end
+        end
+
+        let(:persisted_product) do
+          custom_product_class.create(
+            configuration: Configuration.to_type.cast_value(attributes)
+          )
+        end
+
+        include_examples "for unknown attributes"
+      end
+
       context "when unknown keys are inside nested model" do
         shared_examples "for unknown nested attributes" do
           it { is_expected.to be_a(configuration_class) }


### PR DESCRIPTION
Follow up PR for the discussion in #108.

This PR adds the possibility to configure if unknown attributes get serialized when `as_json` is called on a  `StoreModel::Model` instance.

e.g. to turn of serialization of unknown attributes globally one could set

```ruby
StoreModel.config.serialize_unknown_attributes = false
```

by default this settings is set to `true` to not break the existing behavior.