### PR TITLE
Add access to attributes using brackets

### DIFF
--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -23,6 +23,8 @@ module StoreModel
 
     attr_accessor :parent
 
+    delegate :each_value, :fetch, to: :attributes
+
     # Returns a hash representing the model. Some configuration can be
     # passed through +options+.
     #
@@ -52,6 +54,23 @@ module StoreModel
       attributes.all? { |name, value| value == other.attributes[name] }
     end
     alias eql? ==
+
+    # Accessing attribute using brackets
+    #
+    # @return [Object]
+    def [](attr_name)
+      @attributes.fetch_value(attr_name.to_s)
+    end
+
+    # Setting attribute using brackets
+    #
+    # @param name [String, Symbol]
+    # @param value [Object]
+    #
+    # @return [Object]
+    def []=(attr_name, value)
+      @attributes.write_from_user(attr_name.to_s, value)
+    end
 
     # Returns hash for a StoreModel::Model instance based on attributes hash
     #

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -256,6 +256,34 @@ RSpec.describe StoreModel::Model do
     include_examples "comparing two instances"
   end
 
+  describe "[]" do
+    let(:attributes) { { color: "red" } }
+
+    subject { Configuration.new(attributes) }
+
+    it { expect(subject[:color]).to eq "red" }
+
+    context "when string value is passed" do
+      it { expect(subject["color"]).to eq "red" }
+    end
+  end
+
+  describe "[]=" do
+    let(:attributes) { { color: "red" } }
+
+    subject { Configuration.new(attributes) }
+
+    it do
+      expect { subject[:color] = "black" }.to change { subject[:color] }.to("black")
+    end
+
+    context "when string value is passed" do
+      it do
+        expect { subject[:color] = "black" }.to change { subject[:color] }.to("black")
+      end
+    end
+  end
+
   describe ".to_type" do
     subject { custom_product_class.new }
 


### PR DESCRIPTION
Motivated by [ActiveModel::AttributeSet](https://github.com/rails/rails/blob/c3675f50d2e59b7fc173d7b332860c4b1a24a726/activemodel/lib/active_model/attribute_set.rb#L14-L20), I suggest adding access to attributes using brackets.
When we are using `ActiveRecordModel` and [serialized attributes](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize), we have access to the nested attributes using brackets.