### PR TITLE
🐛  Fix `fetch` to handle `nil` values

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 Metrics/LineLength:
-  Max: 100
+  Max: 120
 
 Metrics/BlockLength:
   Exclude:

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -43,6 +43,28 @@ module StoreModel
       result.as_json(options)
     end
 
+    # Returns an Object, similar to Hash#fetch, raises
+    # a KeyError if attr_name doesn't exist.
+    # @param attr_name [String, Symbol]
+    #
+    # @return Object
+    def fetch(attr_name)
+      stringified_key = attr_name.to_s
+      if attributes.key?(stringified_key)
+        attributes[stringified_key]
+      elsif attribute_names.include?(stringified_key)
+        nil
+      else
+        message = if attr_name.is_a?(Symbol)
+                    "key not found: :#{attr_name}"
+                  else
+                    "key not found: #{attr_name}"
+                  end
+
+        raise KeyError, message
+      end
+    end
+
     # Compares two StoreModel::Model instances
     #
     # @param other [StoreModel::Model]
@@ -56,6 +78,8 @@ module StoreModel
     alias eql? ==
 
     # Accessing attribute using brackets
+    #
+    # @param attr_name [String, Symbol]
     #
     # @return [Object]
     def [](attr_name)

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -50,10 +50,8 @@ module StoreModel
     # @return Object
     def fetch(attr_name)
       stringified_key = attr_name.to_s
-      if attributes.key?(stringified_key)
-        attributes[stringified_key]
-      elsif attribute_names.include?(stringified_key)
-        nil
+      if attribute_names.include?(stringified_key)
+        public_send(stringified_key)
       else
         message = if attr_name.is_a?(Symbol)
                     "key not found: :#{attr_name}"

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -23,7 +23,7 @@ module StoreModel
 
     attr_accessor :parent
 
-    delegate :each_value, :fetch, to: :attributes
+    delegate :each_value, to: :attributes
 
     # Returns a hash representing the model. Some configuration can be
     # passed through +options+.

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -4,6 +4,7 @@ require "store_model/types"
 require "store_model/enum"
 require "store_model/type_builders"
 require "store_model/nested_attributes"
+
 module StoreModel
   # When included into class configures it to handle JSON column
   module Model
@@ -49,7 +50,7 @@ module StoreModel
     # @return Object
     def fetch(attr_name)
       stringified_key = attr_name.to_s
-      if attribute_names.include?(stringified_key)
+      if attribute_names.include?(stringified_key) || attribute_aliases.key?(stringified_key)
         public_send(stringified_key)
       else
         message = attr_name.is_a?(Symbol) ? "key not found: :#{attr_name}" : "key not found: #{attr_name}"

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -4,7 +4,6 @@ require "store_model/types"
 require "store_model/enum"
 require "store_model/type_builders"
 require "store_model/nested_attributes"
-
 module StoreModel
   # When included into class configures it to handle JSON column
   module Model
@@ -53,12 +52,7 @@ module StoreModel
       if attribute_names.include?(stringified_key)
         public_send(stringified_key)
       else
-        message = if attr_name.is_a?(Symbol)
-                    "key not found: :#{attr_name}"
-                  else
-                    "key not found: #{attr_name}"
-                  end
-
+        message = attr_name.is_a?(Symbol) ? "key not found: :#{attr_name}" : "key not found: #{attr_name}"
         raise KeyError, message
       end
     end

--- a/spec/dummy/app/models/configuration.rb
+++ b/spec/dummy/app/models/configuration.rb
@@ -12,8 +12,4 @@ class Configuration
   alias_attribute :enabled, :active
 
   validates :color, presence: true
-
-  def method_attribute
-    super || "bar"
-  end
 end

--- a/spec/dummy/app/models/configuration.rb
+++ b/spec/dummy/app/models/configuration.rb
@@ -6,7 +6,6 @@ class Configuration
   attribute :color, :string
   attribute :model, :string
   attribute :active, :boolean
-  attribute :method_attribute
   attribute :disabled_at, :datetime
 
   alias_attribute :enabled, :active

--- a/spec/dummy/app/models/configuration.rb
+++ b/spec/dummy/app/models/configuration.rb
@@ -6,9 +6,14 @@ class Configuration
   attribute :color, :string
   attribute :model, :string
   attribute :active, :boolean
+  attribute :method_attribute
   attribute :disabled_at, :datetime
 
   alias_attribute :enabled, :active
 
   validates :color, presence: true
+
+  def method_attribute
+    super || "bar"
+  end
 end

--- a/spec/dummy/app/models/method_model.rb
+++ b/spec/dummy/app/models/method_model.rb
@@ -6,6 +6,8 @@ class MethodModel
   attribute :gear, :string
   attribute :tire, :integer
 
+  alias_attribute :foo, :gear
+
   def gear
     super || "gear"
   end

--- a/spec/dummy/app/models/method_model.rb
+++ b/spec/dummy/app/models/method_model.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class MethodModel
+  include StoreModel::Model
+
+  attribute :gear, :string
+  attribute :tire, :integer
+
+  def gear
+    super || "gear"
+  end
+end

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -272,6 +272,7 @@ RSpec.describe StoreModel::Model do
     subject(:configuration) { Configuration.new }
 
     it "fails when fetching nil" do
+      expect(configuration.color).to be_nil
       expect(configuration.fetch(:color)).to be_nil
     end
   end

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -268,6 +268,14 @@ RSpec.describe StoreModel::Model do
     end
   end
 
+  describe "#fetch" do
+    subject(:configuration) { Configuration.new }
+
+    it "fails when fetching nil" do
+      expect(configuration.fetch(:color)).to be_nil
+    end
+  end
+
   describe "[]=" do
     let(:attributes) { { color: "red" } }
 

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -27,26 +27,18 @@ RSpec.describe StoreModel::Model do
   end
 
   describe "#fetch" do
-    let(:instance) { Configuration.new(attributes) }
-    let(:attributes) { { color: "blue" } }
-    let(:attr_name) { :color }
+    let(:instance) { MethodModel.new(attributes) }
+    let(:attributes) { { gear: "blue" } }
+    let(:attr_name) { :gear }
 
     subject(:fetch) { instance.fetch(attr_name) }
 
     it { is_expected.to eq("blue") }
 
     context "when fetching a nil attribute" do
-      let(:attr_name) { :model }
+      let(:attr_name) { :tire }
 
       it { is_expected.to be_nil }
-    end
-
-    context "when fetching a method defined on the model" do
-      let(:attr_name) { :method_attribute }
-
-      it "calls the model method" do
-        is_expected.to eq("bar")
-      end
     end
 
     context "when fetching an attribute that doesn't exist" do

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -26,6 +26,30 @@ RSpec.describe StoreModel::Model do
     end
   end
 
+  describe "#fetch" do
+    let(:instance) { Configuration.new(attributes) }
+    let(:attributes) { { color: "blue" } }
+    let(:attr_name) { :color }
+
+    subject(:fetch) { instance.fetch(attr_name) }
+
+    it { is_expected.to eq("blue") }
+
+    context "when fetching a nil attribute" do
+      let(:attr_name) { :model }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when fetching an attribute that doesn't exist" do
+      let(:attr_name) { :unknown_attribute }
+
+      it "raises a KeyError" do
+        expect { fetch }.to raise_error(KeyError, "key not found: :unknown_attribute")
+      end
+    end
+  end
+
   describe "#as_json" do
     let(:instance) { Configuration.new(attributes) }
 

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe StoreModel::Model do
 
     it { is_expected.to eq("blue") }
 
+    context "when fetching an alias attribute" do
+      it { is_expected.to eq("blue") }
+    end
+
     context "when fetching a nil attribute" do
       let(:attr_name) { :tire }
 

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -268,15 +268,6 @@ RSpec.describe StoreModel::Model do
     end
   end
 
-  describe "#fetch" do
-    subject(:configuration) { Configuration.new }
-
-    it "fails when fetching nil" do
-      expect(configuration.color).to be_nil
-      expect(configuration.fetch(:color)).to be_nil
-    end
-  end
-
   describe "[]=" do
     let(:attributes) { { color: "red" } }
 

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe StoreModel::Model do
       it { is_expected.to be_nil }
     end
 
+    context "when fetching a method defined on the model" do
+      let(:attr_name) { :method_attribute }
+
+      it "calls the model method" do
+        is_expected.to eq("bar")
+      end
+    end
+
     context "when fetching an attribute that doesn't exist" do
       let(:attr_name) { :unknown_attribute }
 


### PR DESCRIPTION
### Context

When relying on delegation of `fetch` to `attributes` there are some issues that can cause unexpected / mis-matched behavior due to the underlying keys in the `attributes` hash.

For example, when we have an object that looks like the following, we'll get different behavior due to `fetch`'s exception handling.

```ruby
class Configuration
  include StoreModel::Model

  attribute :id
end

example = Configuration.new
puts example.id # nil
puts example.fetch(:id) # KeyError: key not found: :id
```

See https://github.com/DmitryTsepelev/store_model/commit/d8c468e817b951d20ba82fdff22a53747357d6f4 which shows the passing behavior, and https://github.com/DmitryTsepelev/store_model/commit/b651dbbc5689c8df72dc37d4773b153a19a1e7f2 which shows the failing behavior.

We discovered this in our usage of a gem called [grape-entity](https://github.com/ruby-grape/grape-entity). At a high-level the gem will do a large amount of delegation, but do some duck-typing [here](https://github.com/ruby-grape/grape-entity/blob/6eac458ddd69117ad979aaab7d1798bb1ba5a349/lib/grape_entity/delegator.rb#L18) to see if the object `respond_to?(:fetch, true)`. Whereas before it would just call `send` on the underlying object.

I feel like we should remove `fetch` from the public api, as it's not promising 1:1 behavior similar to the dot access method. I also realize it's a breaking change for any users who are using the method today, but if I recall it's only been introduced for 2 weeks, so the sooner the better 🤔 

Also want to say that we really love this gem, as it's made managing our JSON backed columns so much easier 💚

Issue: https://github.com/DmitryTsepelev/store_model/issues/129

**Edit**

After some thought, we've decided to make the API safer instead, allowing it to handle `nil` keys!