### PR TITLE
Create class enum accessor

### DIFF
--- a/docs/enums.md
+++ b/docs/enums.md
@@ -18,7 +18,9 @@ config.active? # => false
 config.status_value # => 0
 
 config.status_values # => { :active => 0, :archived => 1 }
+config.statuses # => { :active => 0, :archived => 1 }
 Configuration.status_values # => { :active => 0, :archived => 1 }
+Configuration.statuses # => { :active => 0, :archived => 1 }
 ```
 
 Under the hood, values are stored as integers, according to the index of the element in the array:

--- a/docs/enums.md
+++ b/docs/enums.md
@@ -18,6 +18,7 @@ config.active? # => false
 config.status_value # => 0
 
 config.status_values # => { :active => 0, :archived => 1 }
+Configuration.status_values # => { :active => 0, :archived => 1 }
 ```
 
 Under the hood, values are stored as integers, according to the index of the element in the array:

--- a/lib/store_model/enum.rb
+++ b/lib/store_model/enum.rb
@@ -18,6 +18,7 @@ module StoreModel
         define_writer(name, mapping)
         define_method("#{name}_value") { attributes[name.to_s] }
         define_method("#{name}_values") { mapping }
+        singleton_class.define_method("#{name}_values") { mapping }
         define_predicate_methods(name, mapping, options)
       end
     end

--- a/lib/store_model/enum.rb
+++ b/lib/store_model/enum.rb
@@ -17,10 +17,7 @@ module StoreModel
         define_reader(name, mapping)
         define_writer(name, mapping)
         define_method("#{name}_value") { attributes[name.to_s] }
-        define_method("#{name}_values") { mapping }
-        alias_method(ActiveSupport::Inflector.pluralize(name), "#{name}_values")
-        singleton_class.define_method("#{name}_values") { mapping }
-        singleton_class.alias_method(ActiveSupport::Inflector.pluralize(name), "#{name}_values")
+        define_map_readers(name, mapping)
         define_predicate_methods(name, mapping, options)
       end
     end
@@ -45,6 +42,13 @@ module StoreModel
         label = affixed_label(label, name, options[:_prefix], options[:_suffix])
         define_method("#{label}?") { send(name) == mapping.key(value).to_s }
       end
+    end
+
+    def define_map_readers(name, mapping)
+      define_method("#{name}_values") { mapping }
+      alias_method(ActiveSupport::Inflector.pluralize(name), "#{name}_values")
+      singleton_class.define_method("#{name}_values") { mapping }
+      singleton_class.alias_method(ActiveSupport::Inflector.pluralize(name), "#{name}_values")
     end
 
     def cast_type(mapping)

--- a/lib/store_model/enum.rb
+++ b/lib/store_model/enum.rb
@@ -18,7 +18,9 @@ module StoreModel
         define_writer(name, mapping)
         define_method("#{name}_value") { attributes[name.to_s] }
         define_method("#{name}_values") { mapping }
+        alias_method(ActiveSupport::Inflector.pluralize(name), "#{name}_values")
         singleton_class.define_method("#{name}_values") { mapping }
+        singleton_class.alias_method(ActiveSupport::Inflector.pluralize(name), "#{name}_values")
         define_predicate_methods(name, mapping, options)
       end
     end

--- a/spec/store_model/enum_spec.rb
+++ b/spec/store_model/enum_spec.rb
@@ -35,6 +35,27 @@ RSpec.describe StoreModel::Model do
     expect(subject.status_values).to eq(active: 1, archived: 0)
   end
 
+  it "has .values class method" do
+    expect(config_class.status_values).to eq(active: 1, archived: 0)
+  end
+
+  context "when multiple StoreModel classes are defined" do
+    let!(:another_config_class) do
+      Class.new do
+        include StoreModel::Model
+
+        enum :status, off: 0, on: 1
+        enum :level, low: 1, medium: 2, high: 3
+      end
+    end
+
+    it "does not share enum mapping methods between classes" do
+      expect(another_config_class.status_values).to eq(off: 0, on: 1)
+      expect(config_class.status_values).to eq(active: 1, archived: 0)
+      expect(config_class.respond_to?(:level_values)).to eq(false)
+    end
+  end
+
   context "when value is not in the list" do
     let(:value) { "undefined" }
 

--- a/spec/store_model/enum_spec.rb
+++ b/spec/store_model/enum_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe StoreModel::Model do
     expect(config_class.status_values).to eq(active: 1, archived: 0)
   end
 
+  it "aliases the pluralized name to the #values method" do
+    expect(subject.statuses).to eq(subject.status_values)
+  end
+
+  it "aliases the pluralized name to the .values method" do
+    expect(config_class.statuses).to eq(config_class.status_values)
+  end
+
   context "when multiple StoreModel classes are defined" do
     let!(:another_config_class) do
       Class.new do


### PR DESCRIPTION
# Intro 👋 

Hi there! I hope it was all right to open this PR directly. I'm a first-time contributor so go easy on me and let me know how you'd like me to contribute this, if it's welcome.

# This PR

Take a class with an enum defined:

```ruby
class Configuration
  include StoreModel::Model

  enum :status, {off: 0, on: 1}
end
```

Currently, it's only possible to access the enum mapping on instances:

```ruby
Configuration.new.status_values # => {:off=>0, :on=>1}
```

But the mapping is defined on the class, so there's no reason this shouldn't also work, which is how it also works in ActiveRecord:
```ruby
Configuration.status_values # => {:off=>0, :on=>1}
```

This PR defines that method on the class.

## Bonus

In Rails, it's also possible to access the enum mapping via the pluralized enum name, e.g.
```ruby
Configuration.statuses
```

instead of

```ruby
Configuration.status_values
```

To support both the Rails style pluralized name style as well as the current StoreModel style, I also added aliases with the Rails-style names to the StoreModel-style names.