### PR TITLE
Support option "allow_destroy" to accepts_nested_attributes_for

### DIFF
--- a/lib/store_model/nested_attributes.rb
+++ b/lib/store_model/nested_attributes.rb
@@ -10,16 +10,38 @@ module StoreModel
     module ClassMethods # :nodoc:
       # Enables handling of nested StoreModel::Model attributes
       #
-      # @param associations [Array] list of associations to define attributes
+      # @param associations [Array] list of associations and options to define attributes, for example:
+      #   accepts_nested_attributes_for [:suppliers, allow_destroy: true]
+      #
+      # Supported options:
+      # [:allow_destroy]
+      #   If true, destroys any members from the attributes hash with a
+      #   <tt>_destroy</tt> key and a value that evaluates to +true+
+      #   (e.g. 1, '1', true, or 'true'). This option is off by default.
       def accepts_nested_attributes_for(*associations)
-        associations.each do |association|
+        associations.each do |association, options|
           case attribute_types[association.to_s]
           when Types::One
+            define_association_setter(association, options)
             alias_method "#{association}_attributes=", "#{association}="
           when Types::Many
             define_method "#{association}_attributes=" do |attributes|
-              assign_nested_attributes_for_collection_association(association, attributes)
+              assign_nested_attributes_for_collection_association(association, attributes, options)
             end
+          end
+        end
+      end
+
+      private
+
+      def define_association_setter(association, options)
+        return unless options&.dig(:allow_destroy)
+
+        define_method "#{association}=" do |attributes|
+          if attributes.stringify_keys.dig("_destroy") == "1"
+            super(nil)
+          else
+            super(attributes)
           end
         end
       end
@@ -27,8 +49,11 @@ module StoreModel
 
     private
 
-    def assign_nested_attributes_for_collection_association(association, attributes)
+    def assign_nested_attributes_for_collection_association(association, attributes, options)
       attributes = attributes.values if attributes.is_a?(Hash)
+
+      attributes.reject! { |attribute| attribute.stringify_keys.dig("_destroy") == "1" } if options&.dig(:allow_destroy)
+
       send "#{association}=", attributes
     end
   end

--- a/spec/store_model/nested_attributes_spec.rb
+++ b/spec/store_model/nested_attributes_spec.rb
@@ -81,6 +81,73 @@ RSpec.describe StoreModel::NestedAttributes do
       it("assigns attributes to nested model") do
         expect(subject.supplier).to have_attributes(supplier1)
       end
+
+      context "and allow_destroy is true" do
+        let(:configuration_class) do
+          Class.new do
+            include StoreModel::Model
+
+            attribute :color, :string
+            attribute :supplier, Supplier.to_type
+
+            accepts_nested_attributes_for [:supplier, { allow_destroy: true }]
+          end
+        end
+
+        before { supplier1[:_destroy] = _destroy }
+
+        context "and _destroy is 1" do
+          let(:_destroy) { "1" }
+
+          it("does not assign attributes to nested model") do
+            expect(subject.supplier).to be_nil
+          end
+        end
+
+        context "and _destroy is 0" do
+          let(:_destroy) { "0" }
+
+          it("assigns attributes to nested model") do
+            expect(subject.supplier).to have_attributes(supplier1.except(:_destroy))
+          end
+        end
+      end
+    end
+
+    context "when allow_destroy is true" do
+      let(:configuration_class) do
+        Class.new do
+          include StoreModel::Model
+
+          attribute :color, :string
+          attribute :suppliers, Supplier.to_array_type
+
+          accepts_nested_attributes_for [:suppliers, { allow_destroy: true }]
+        end
+      end
+
+      before { supplier1[:_destroy] = _destroy }
+
+      context "and _destroy is 1" do
+        let(:_destroy) { "1" }
+
+        it "assigns only supplier2" do
+          expect(subject.suppliers).to contain_exactly(
+            have_attributes(supplier2)
+          )
+        end
+      end
+
+      context "and _destroy is 0" do
+        let(:_destroy) { "0" }
+
+        it "assigns attributes to nested model" do
+          expect(subject.suppliers).to contain_exactly(
+            have_attributes(supplier1.except(:_destroy)),
+            have_attributes(supplier2)
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Similar to the `accepts_nested_attributes_for` active record, the idea here is to support the `allow_destroy` option in the `accepts_nested_attributes_for` store_model method.

For example:
`accepts_nested_attributes_for [:suppliers, allow_destroy: true]`

Active Record documentation: https://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html#method-i-accepts_nested_attributes_for
