### PR TITLE
fix: Add _destroy attr_accessor for association in nested attributes

### DIFF
--- a/lib/store_model/nested_attributes.rb
+++ b/lib/store_model/nested_attributes.rb
@@ -27,10 +27,20 @@ module StoreModel
           when Types::Many
             define_association_setter_for_many(association, options)
           end
+
+          define_attr_accessor_for_destroy(association, options)
         end
       end
 
       private
+
+      def define_attr_accessor_for_destroy(association, options)
+        return unless options&.dig(:allow_destroy)
+
+        attribute_types[association.to_s].model_klass.class_eval do
+          attr_accessor :_destroy
+        end
+      end
 
       def define_association_setter_for_many(association, options)
         define_method "#{association}_attributes=" do |attributes|

--- a/lib/store_model/types/many_base.rb
+++ b/lib/store_model/types/many_base.rb
@@ -7,6 +7,8 @@ module StoreModel
     # Implements ActiveModel::Type::Value type for handling an array of
     # StoreModel::Model
     class ManyBase < ActiveModel::Type::Value
+      attr_reader :model_klass
+
       # Returns type
       #
       # @return [Symbol]

--- a/lib/store_model/types/one_base.rb
+++ b/lib/store_model/types/one_base.rb
@@ -6,6 +6,8 @@ module StoreModel
   module Types
     # Implements ActiveModel::Type::Value type for handling an instance of StoreModel::Model
     class OneBase < ActiveModel::Type::Value
+      attr_reader :model_klass
+
       # Returns type
       #
       # @return [Symbol]

--- a/spec/store_model/nested_attributes_spec.rb
+++ b/spec/store_model/nested_attributes_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe StoreModel::NestedAttributes do
         end
 
         before { supplier1[:_destroy] = _destroy }
+        let(:_destroy) { "0" }
 
         context "and _destroy is 1" do
           let(:_destroy) { "1" }
@@ -110,6 +111,11 @@ RSpec.describe StoreModel::NestedAttributes do
           it("assigns attributes to nested model") do
             expect(subject.supplier).to have_attributes(supplier1.except(:_destroy))
           end
+        end
+
+        it "defines _destroy attribute" do
+          expect(subject.supplier).to respond_to(:_destroy)
+          expect(subject.supplier).to respond_to(:_destroy=)
         end
       end
     end
@@ -127,6 +133,12 @@ RSpec.describe StoreModel::NestedAttributes do
       end
 
       before { supplier1[:_destroy] = _destroy }
+      let(:_destroy) { "0" }
+
+      it "defines _destroy attribute" do
+        expect(subject.suppliers.first).to respond_to(:_destroy)
+        expect(subject.suppliers.first).to respond_to(:_destroy=)
+      end
 
       context "and _destroy is 1" do
         let(:_destroy) { "1" }


### PR DESCRIPTION
This is an improvement for [this PR](https://github.com/DmitryTsepelev/store_model/pull/138).

The idea here is to automatically adds `_destroy` attribute in the association class when `allow_destroy` is true.

## Example

```ruby
class Requirement
  attribute :categories, Category.to_array_type
  accepts_nested_attributes_for [:categories, { allow_destroy: true }]
end
```

### Without this PR
```ruby
class Category
  include StoreModel::Model

  attr_accessor :_destroy
end
```

### With this PR
```ruby
class Category
  include StoreModel::Model
end
```