### PR TITLE
Remove enum mapping instance method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR #136](https://github.com/DmitryTsepelev/store_model/pull/136) Remove enum mapping instance method ([@jas14])
+
 ## 1.6.0 (2023-02-19)
 
 - [PR #135](https://github.com/DmitryTsepelev/store_model/pull/135) Create class enum accessor ([@jas14])

--- a/docs/enums.md
+++ b/docs/enums.md
@@ -18,7 +18,6 @@ config.active? # => false
 config.status_value # => 0
 
 config.status_values # => { :active => 0, :archived => 1 }
-config.statuses # => { :active => 0, :archived => 1 }
 Configuration.status_values # => { :active => 0, :archived => 1 }
 Configuration.statuses # => { :active => 0, :archived => 1 }
 ```

--- a/lib/store_model/enum.rb
+++ b/lib/store_model/enum.rb
@@ -46,7 +46,6 @@ module StoreModel
 
     def define_map_readers(name, mapping)
       define_method("#{name}_values") { mapping }
-      alias_method(ActiveSupport::Inflector.pluralize(name), "#{name}_values")
       singleton_class.define_method("#{name}_values") { mapping }
       singleton_class.alias_method(ActiveSupport::Inflector.pluralize(name), "#{name}_values")
     end

--- a/spec/store_model/enum_spec.rb
+++ b/spec/store_model/enum_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe StoreModel::Model do
     expect(config_class.status_values).to eq(active: 1, archived: 0)
   end
 
-  it "aliases the pluralized name to the #values method" do
-    expect(subject.statuses).to eq(subject.status_values)
+  it "does not alias the pluralized name to the #values method" do
+    expect(subject).not_to respond_to(:statuses)
   end
 
   it "aliases the pluralized name to the .values method" do
@@ -61,6 +61,27 @@ RSpec.describe StoreModel::Model do
       expect(another_config_class.status_values).to eq(off: 0, on: 1)
       expect(config_class.status_values).to eq(active: 1, archived: 0)
       expect(config_class.respond_to?(:level_values)).to eq(false)
+    end
+  end
+
+  context "when enum name is already pluralized" do
+    let(:config_class) do
+      Class.new do
+        include StoreModel::Model
+
+        enum :amounts, in: { many: 0, few: 1 }
+      end
+    end
+
+    subject { config_class.new(amounts: :many) }
+
+    it "aliases the name to the .values method" do
+      expect(config_class.amounts).to eq(config_class.amounts_values)
+    end
+
+    it "does not alias the name to the #values method" do
+      expect(subject.amounts).to eq("many")
+      expect(subject.amounts).not_to eq(subject.amounts_values)
     end
   end
 


### PR DESCRIPTION
As @BoberMod pointed out in https://github.com/DmitryTsepelev/store_model/pull/135#discussion_r1124487764, that PR introduces a regression in cases where the name of an enum is already pluralized; specifically, the instance method to access the enum _value_ is superseded with the instance method to access the enum _mapping_.

Since there's already a _class_ method to access the enum mapping, and the precedent (in ActiveRecord) doesn't set an instance method to access the enum mapping anyway, this PR removes the instance method to access the enum mapping.

I hope the diff in `docs/enums.md` and the specs sufficiently illustrate the practical difference!