### PR TITLE
Propogate validation context to store model

### DIFF
--- a/lib/active_model/validations/store_model_validator.rb
+++ b/lib/active_model/validations/store_model_validator.rb
@@ -22,20 +22,20 @@ module ActiveModel
 
         case record.type_for_attribute(attribute).type
         when :json, :polymorphic
-          call_json_strategy(attribute, record.errors, value)
+          call_json_strategy(record, attribute, value)
         when :array, :polymorphic_array
-          call_array_strategy(attribute, record.errors, value)
+          call_array_strategy(record, attribute, value)
         end
       end
 
       private
 
-      def call_json_strategy(attribute, record_errors, value)
-        strategy.call(attribute, record_errors, value.errors) if value.invalid?
+      def call_json_strategy(record, attribute, value)
+        strategy.call(attribute, record.errors, value.errors) if value.invalid?(record.validation_context)
       end
 
-      def call_array_strategy(attribute, record_errors, value)
-        array_strategy.call(attribute, record_errors, value) if value.select(&:invalid?).present?
+      def call_array_strategy(record, attribute, value)
+        array_strategy.call(attribute, record.errors, value) if value.select {|v| v.invalid?(record.validation_context) }.present?
       end
 
       def strategy

--- a/spec/active_model/validations/store_model_validator_spec.rb
+++ b/spec/active_model/validations/store_model_validator_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe ActiveModel::Validations::StoreModelValidator do
           expect(subject.errors.full_messages).to eq(["Configuration can't be blank"])
         end
       end
+
+      context "with contextual validations" do
+        let(:attributes) { { configuration: Configuration.new(color: "red") } }
+
+        it "propogates context" do
+          expect(subject).to be_valid
+          expect(subject).to be_invalid(:custom_context)
+        end
+      end
     end
 
     context "with allow_nil: true" do
@@ -106,6 +115,11 @@ RSpec.describe ActiveModel::Validations::StoreModelValidator do
 
           expect(subject.configurations.second.errors.messages).to be_empty
           expect(subject.configurations.second.errors.full_messages).to be_empty
+        end
+
+        it "propogates context" do
+          expect(subject).to be_valid
+          expect(subject).to be_invalid(:custom_context)
         end
       end
 

--- a/spec/dummy/app/models/configuration.rb
+++ b/spec/dummy/app/models/configuration.rb
@@ -11,4 +11,5 @@ class Configuration
   alias_attribute :enabled, :active
 
   validates :color, presence: true
+  validates :model, presence: true, on: :custom_context
 end


### PR DESCRIPTION
When we validate a model with a specific context, also validate its stores under that context.

See #141 