### PR TITLE
Enums are incorrectly serialized using as_json

### DIFF
--- a/spec/dummy/app/models/configuration.rb
+++ b/spec/dummy/app/models/configuration.rb
@@ -22,6 +22,8 @@ class Configuration
   attribute :disabled_at, :datetime
   attribute :encrypted_serial, Encrypted.new
 
+  enum :type, { left: 1, right: 2 }
+
   alias_attribute :enabled, :active
 
   validates :color, presence: true

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe StoreModel::Model do
       model: nil,
       active: false,
       disabled_at: Time.new(2019, 2, 10, 12),
-      encrypted_serial: nil
+      encrypted_serial: nil,
+      type: :left
     }
   end
 


### PR DESCRIPTION
It appears that enum attributes aren't properly being serialized using `as_json`.

I've attached a failing test case for it - I'd expect the configuration as json to convert back from integer to stringified-symbol of the enum key.