### PR TITLE
Use accepts_nested_attributes_for with StoreModel::NestedAttributes

### DIFF
--- a/spec/dummy/app/models/store.rb
+++ b/spec/dummy/app/models/store.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Store < ActiveRecord::Base
+  include StoreModel::NestedAttributes
+
+  has_many :products, dependent: :destroy
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -3,6 +3,11 @@
 ActiveRecord::Schema.define(version: 2019_02_216_153105) do
   create_table :products do |t|
     t.string :name
+    t.references :store, null: true
     t.json :configuration, default: {}
+  end
+
+  create_table :stores do |t|
+    t.json :bicycles, default: []
   end
 end

--- a/spec/store_model/nested_attributes_spec.rb
+++ b/spec/store_model/nested_attributes_spec.rb
@@ -200,4 +200,30 @@ RSpec.describe StoreModel::NestedAttributes do
       it { is_expected.to be_invalid }
     end
   end
+
+  context "when mixed in to an activerecord model" do
+    let(:model_class) { Store }
+
+    describe "#accepts_nested_attributes_for" do
+      context "with standard rails syntax" do
+        subject {
+          model_class.accepts_nested_attributes_for(:products, allow_destroy: true)
+          model_class.new
+        }
+
+        it { is_expected.to respond_to(:products_attributes=) }
+      end
+
+      context "allows mixing associations with attributes" do
+        subject {
+          model_class.attribute :bicycles, Bicycle.to_array_type
+          model_class.accepts_nested_attributes_for(:products, :bicycles, allow_destroy: true)
+          model_class.new
+        }
+
+        it { is_expected.to respond_to(:products_attributes=) }
+        it { is_expected.to respond_to(:bicycles_attributes=) }
+      end
+    end
+  end
 end

--- a/spec/store_model/nested_attributes_spec.rb
+++ b/spec/store_model/nested_attributes_spec.rb
@@ -206,20 +206,20 @@ RSpec.describe StoreModel::NestedAttributes do
 
     describe "#accepts_nested_attributes_for" do
       context "with standard rails syntax" do
-        subject {
+        subject do
           model_class.accepts_nested_attributes_for(:products, allow_destroy: true)
           model_class.new
-        }
+        end
 
         it { is_expected.to respond_to(:products_attributes=) }
       end
 
       context "allows mixing associations with attributes" do
-        subject {
+        subject do
           model_class.attribute :bicycles, Bicycle.to_array_type
           model_class.accepts_nested_attributes_for(:products, :bicycles, allow_destroy: true)
           model_class.new
-        }
+        end
 
         it { is_expected.to respond_to(:products_attributes=) }
         it { is_expected.to respond_to(:bicycles_attributes=) }


### PR DESCRIPTION
This makes it possible to use the complete Rails pathway for nested form objects.

Also updates `accepts_nested_attributes_for` to allow the Rails-syntax.

```ruby
class Supplier < ActiveRecord::Base
  include StoreModel::NestedAttributes

  has_many :bicycles, dependent: :destroy

  attribute :products, Product.to_array_type

  accepts_nested_attributes_for :bicycles, :products, allow_destroy: true
end
```

This will allow the form builders to work their magic:

```erb
<%= form_with model: @supplier do |form| %>
  <%= form.fields_for :products do |product_fields| %>
    <%= product_fields.text_field :name %>
  <% end %>
<% end %>
```

Resulting in:
```html
<input type="text" name="supplier[products_attributes][0][name]" id="supplier_products_attributes_0_name">
```

In the controller:
```ruby
def create
  @supplier = Supplier.new(supplier_params)
  @supplier.save
end

private

def supplier_params
  params.require(:supplier).permit(products_attributes: [:name])
end
```