### PR TITLE
Model#as_json serializes key-value enums using keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change log
 
+## 3.0.0 (eventually)
+
+- Make `StoreModel.config.serialize_enums_using_as_json = true` default
+
 ## master
+
+- [PR #153](https://github.com/DmitryTsepelev/store_model/pull/153) Model#as_json serializes key-value enums using keys  ([@DmitryTsepelev])
 
 ## 2.0.1 (2023-05-09)
 

--- a/docs/enums.md
+++ b/docs/enums.md
@@ -38,6 +38,14 @@ class Review
 end
 ```
 
+There was a [bug](https://github.com/DmitryTsepelev/store_model/pull/151) related to `:in` causing values to be returned from `#as_json`:
+
+```ruby
+Review.new(rating: :okay).as_json # => "{\"type\": 1}"
+```
+
+Please use `StoreModel.config.serialize_enums_using_as_json = true` to turn this behavior on; this will be a new default in the next major release.
+
 You can use the `:_prefix` or `:_suffix` options when you need to define multiple enums with same values. If the passed value is true, the methods are prefixed/suffixed with the name of the enum. It is also possible to supply a custom value:
 
 ```ruby
@@ -58,5 +66,4 @@ review.archived_status? # => false
 
 review.comments_active? # => false
 review.comments_inactive? # => true
-
 ```

--- a/lib/store_model/configuration.rb
+++ b/lib/store_model/configuration.rb
@@ -15,6 +15,10 @@ module StoreModel
     # @return [Boolean]
     attr_accessor :serialize_unknown_attributes
 
+    # Controls if the result of `as_json` will serialize enum fiels using `as_json`
+    # @return [Boolean]
+    attr_accessor :serialize_enums_using_as_json
+
     def initialize
       @serialize_unknown_attributes = true
     end

--- a/spec/dummy/app/models/configuration.rb
+++ b/spec/dummy/app/models/configuration.rb
@@ -26,4 +26,6 @@ class Configuration
 
   validates :color, presence: true
   validates :model, presence: true, on: :custom_context
+
+  enum :type, in: { left: 1, right: 2 }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,7 @@ RSpec.configure do |config|
 
   config.after(:each) do
     StoreModel.remove_instance_variable(:@config) if StoreModel.instance_variable_defined?(:@config)
+    StoreModel.config.serialize_enums_using_as_json = true
   end
 end
 

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe StoreModel::Model do
       model: nil,
       active: false,
       disabled_at: Time.new(2019, 2, 10, 12),
-      encrypted_serial: nil
+      encrypted_serial: nil,
+      type: "left"
     }
   end
 
@@ -77,6 +78,14 @@ RSpec.describe StoreModel::Model do
     subject { instance.as_json }
 
     it("returns correct JSON") { is_expected.to eq(attributes.as_json) }
+
+    context "when serialize_enums_using_as_json is off" do
+      before do
+        StoreModel.config.serialize_enums_using_as_json = false
+      end
+
+      it("returns correct JSON") { is_expected.to eq(attributes.merge(type: 1).as_json) }
+    end
 
     context "with only" do
       subject { instance.as_json(only: %i[color]) }
@@ -158,7 +167,7 @@ RSpec.describe StoreModel::Model do
     it "prints description" do
       expect(subject).to eq(
         "#<Configuration color: red, model: nil, active: false, " \
-        "disabled_at: #{attributes[:disabled_at]}, encrypted_serial: nil>"
+        "disabled_at: #{attributes[:disabled_at]}, encrypted_serial: nil, type: 1>"
       )
     end
   end

--- a/spec/store_model/types/one_polymorphic_spec.rb
+++ b/spec/store_model/types/one_polymorphic_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe StoreModel::Types::OnePolymorphic do
       model: nil,
       active: false,
       disabled_at: Time.new(2019, 2, 22, 12, 30),
-      encrypted_serial: nil
+      encrypted_serial: nil,
+      type: "left"
     }
   end
 

--- a/spec/store_model/types/one_spec.rb
+++ b/spec/store_model/types/one_spec.rb
@@ -174,22 +174,30 @@ RSpec.describe StoreModel::Types::One do
       subject { type.serialize(value) }
 
       it { is_expected.to be_a(String) }
+
       it("is equal to attributes") { is_expected.to eq(attributes.to_json) }
     end
 
     context "when Hash is passed" do
       let(:value) { attributes }
+
       include_examples "serialize examples"
     end
 
     context "when String is passed" do
       let(:value) { ActiveSupport::JSON.encode(attributes) }
+
       include_examples "serialize examples"
     end
 
     context "when Configuration instance is passed" do
       let(:value) { Configuration.new(attributes) }
-      include_examples "serialize examples"
+
+      subject { type.serialize(value) }
+
+      it { is_expected.to be_a(String) }
+
+      it("is equal to attributes") { is_expected.to eq(attributes.merge(type: nil).to_json) }
     end
   end
 end


### PR DESCRIPTION
Fixes #151. Turn on the config option `StoreModel.config.serialize_enums_using_as_json = true`