### PR TITLE
Fix serialization on nested objects

### DIFF
--- a/lib/store_model/types.rb
+++ b/lib/store_model/types.rb
@@ -14,6 +14,8 @@ require "store_model/types/enum_type"
 
 require "store_model/types/one_of"
 
+require "store_model/types/raw_json"
+
 module StoreModel
   # Contains all custom types.
   module Types

--- a/lib/store_model/types/one.rb
+++ b/lib/store_model/types/one.rb
@@ -46,9 +46,7 @@ module StoreModel
       # @return [String] serialized value
       def serialize(value)
         case value
-        when @model_klass
-          ActiveSupport::JSON.encode(value.values_for_database)
-        when Hash
+        when @model_klass, Hash
           ActiveSupport::JSON.encode(value)
         else
           super

--- a/lib/store_model/types/raw_json.rb
+++ b/lib/store_model/types/raw_json.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module StoreModel
+  module Types
+    # Implements #encode_json and #as_json methods.
+    # By wrapping serialized objects in this type, it prevents duplicate
+    # JSON serialization passes on nested object. It is named as Encoder
+    # as it will not work to inflate typed attributes and is intended
+    # to be used internally.
+    class RawJSONEncoder < String
+      def encode_json(_encoder)
+        self
+      end
+
+      def as_json(_options = nil)
+        JSON.parse(self)
+      end
+    end
+  end
+end

--- a/spec/dummy/app/models/anything.rb
+++ b/spec/dummy/app/models/anything.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Anything < ActiveRecord::Base
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,4 +10,9 @@ ActiveRecord::Schema.define(version: 2019_02_216_153105) do
   create_table :stores do |t|
     t.json :bicycles, default: []
   end
+
+  create_table :anythings do |t|
+    t.json :store, default: {}
+    t.string :type
+  end
 end

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe StoreModel::Model do
       color: "red",
       model: nil,
       active: false,
-      disabled_at: Time.new(2019, 2, 10, 12),
+      disabled_at: Time.new(2019, 2, 10, 12).utc,
       encrypted_serial: nil,
       type: "left"
     }
@@ -35,7 +35,7 @@ RSpec.describe StoreModel::Model do
           color: "red",
           model: nil,
           active: false,
-          disabled_at: Time.new(2019, 2, 10, 12),
+          disabled_at: Time.new(2019, 2, 10, 12).utc,
           encrypted_serial: "111-222"
         }
       end

--- a/spec/store_model/types/many_polymorphic_spec.rb
+++ b/spec/store_model/types/many_polymorphic_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe StoreModel::Types::ManyPolymorphic do
     [
       {
         color: "red",
-        disabled_at: Time.new(2019, 2, 22, 12, 30)
+        disabled_at: Time.new(2019, 2, 22, 12, 30).utc
       },
       {
         color: "green",
-        disabled_at: Time.new(2019, 3, 12, 8, 10)
+        disabled_at: Time.new(2019, 3, 12, 8, 10).utc
       }
     ]
   end

--- a/spec/store_model/types/many_spec.rb
+++ b/spec/store_model/types/many_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe StoreModel::Types::Many do
     [
       {
         color: "red",
-        disabled_at: Time.new(2019, 2, 22, 12, 30)
+        disabled_at: Time.new(2019, 2, 22, 12, 30).utc
       },
       {
         color: "green",
-        disabled_at: Time.new(2019, 3, 12, 8, 10)
+        disabled_at: Time.new(2019, 3, 12, 8, 10).utc
       }
     ]
   end

--- a/spec/store_model/types/one_polymorphic_spec.rb
+++ b/spec/store_model/types/one_polymorphic_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe StoreModel::Types::OnePolymorphic do
       color: "red",
       model: nil,
       active: false,
-      disabled_at: Time.new(2019, 2, 22, 12, 30),
+      disabled_at: Time.new(2019, 2, 22, 12, 30).utc,
       encrypted_serial: nil,
       type: "left"
     }


### PR DESCRIPTION
Fixes #150, which tracks a breaking change in serialization and persistence of json object.

After `v1.6.2`, nested models received multiple serialization passes. This broke all json queries against the persisted rows. I merged in the test which @trumanshuck used to isolate the version, then added a fix from there.

This PR removes `values_for_database` and patches `as_json` so nested `Hash` and `StoreModel` attributes will only serialized as JSON once. For array attributes, it delegates to `as_json`, so they are safe as well.

This ensures:
- the entire object and all nested attributes are query-able through your database's particular json syntax
- all nested attribute's `Type` will be used for serialization/deserialization, so things like timestamps and encryption work.