### PR TITLE
Override of accepts_nested_attributes_for breaks app start when connection to db is not available

### DIFF
--- a/lib/store_model/nested_attributes.rb
+++ b/lib/store_model/nested_attributes.rb
@@ -41,8 +41,6 @@ module StoreModel
           case nested_attribute_type(attribute)
           when Types::OneBase, Types::ManyBase
             options.reverse_merge!(allow_destroy: false, update_only: false)
-            options.assert_valid_keys(:allow_destroy, :reject_if, :limit, :update_only)
-
             define_store_model_attr_accessors(attribute, options)
           else
             super(*attribute, options)
@@ -73,7 +71,9 @@ module StoreModel
         case nested_attribute_type(attribute)
         when Types::OneBase
           define_association_setter_for_single(attribute, options)
-          alias_method "#{attribute}_attributes=", "#{attribute}="
+          define_method "#{attribute}_attributes=" do |*args, **kwargs|
+            send("#{attribute}=", *args, **kwargs)
+          end
         when Types::ManyBase
           define_association_setter_for_many(attribute, options)
         end
@@ -109,7 +109,7 @@ module StoreModel
     end
 
     # Base
-    def assign_nested_attributes_for_collection_association(association, attributes, options=nil)
+    def assign_nested_attributes_for_collection_association(association, attributes, options = nil)
       return super(association, attributes) unless options
 
       attributes = attributes.values if attributes.is_a?(Hash)

--- a/spec/store_model/nested_attributes_spec.rb
+++ b/spec/store_model/nested_attributes_spec.rb
@@ -400,7 +400,9 @@ RSpec.describe StoreModel::NestedAttributes do
           Class.new(ActiveRecord::Base) do
             include StoreModel::NestedAttributes
 
-            def self.name = "invalid_table_name"
+            def self.name
+              "invalid_table_name"
+            end
 
             attribute :suppliers, Supplier.to_array_type
           end

--- a/spec/store_model/nested_attributes_spec.rb
+++ b/spec/store_model/nested_attributes_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe StoreModel::NestedAttributes do
             attribute :color, :string
             attribute :supplier, Supplier.to_type
 
-            accepts_nested_attributes_for [:supplier, { allow_destroy: true }]
+            accepts_nested_attributes_for :supplier, allow_destroy: true
           end
         end
 
@@ -214,7 +214,7 @@ RSpec.describe StoreModel::NestedAttributes do
           attribute :color, :string
           attribute :suppliers, Supplier.to_array_type
 
-          accepts_nested_attributes_for [:suppliers, { allow_destroy: true }]
+          accepts_nested_attributes_for :suppliers, allow_destroy: true
         end
       end
 
@@ -388,6 +388,26 @@ RSpec.describe StoreModel::NestedAttributes do
 
         it { is_expected.to respond_to(:products_attributes=) }
         it { is_expected.to respond_to(:bicycles_attributes=) }
+      end
+
+      context "when db is not connected" do
+        subject do
+          model_class.accepts_nested_attributes_for(:suppliers)
+          model_class
+        end
+
+        let(:model_class) do
+          Class.new(ActiveRecord::Base) do
+            include StoreModel::NestedAttributes
+
+            def self.name = "invalid_table_name"
+
+            attribute :suppliers, Supplier.to_array_type
+          end
+        end
+
+        it { expect { subject }.not_to(raise_error) }
+        it { expect(subject.instance_methods).to(include(:suppliers_attributes=)) }
       end
     end
   end


### PR DESCRIPTION
Override of accepts_nested_attributes_for was calling for attribute_types method which is taking attribute types from schema if your model is active-record, which will not work when you do not yet have db prepared or your new model is not yet created in database but you already declared everything in your model's class. In some cases it was preventing of 'rails db:create' and 'rails db:migrate'

Override of assign_nested_attributes_for_collection_association was accepting more arguments than it's super method declared in active record, which was breaking one_to_many relations with accept_nested_attributes_for this relation.

Also, plain rails do not support per relation declaration of options for accepts_nested_attributes_for (https://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html#method-i-accepts_nested_attributes_for) e.g. so i don't see the reason why it should be there to potentially break default behaviour.

```
# Bad
accepts_nested_attributes_for [:supplier, allow_destroy: true], [:service_center, update_only: true]

# Good
accepts_nested_attributes_for :supplier, allow_destroy: true
accepts_nested_attributes_for :service_center, update_only: true
```

Fix accepts_nested_attributes_for raising error when database is not initialized or table for model doesnt exist

Fix assign_nested_attributes_for_collection_association override breaking ActiveRecord::Base#accepts_nested_attributes_for for non storemodel relations