### PR TITLE
Improve `inspect` readability

### DIFF
--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -118,7 +118,7 @@ module StoreModel
     #
     # @return [String]
     def inspect
-      attribute_string = attributes.map { |name, value| "#{name}: #{value.nil? ? 'nil' : value}" }
+      attribute_string = attributes.map { |name, value| "#{name}: #{value.inspect}" }
                                    .join(", ")
       "#<#{self.class.name} #{attribute_string}>"
     end

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe StoreModel::Model do
 
     it "prints description" do
       expect(subject).to eq(
-        "#<Configuration color: red, model: nil, active: false, " \
+        "#<Configuration color: \"red\", model: nil, active: false, " \
         "disabled_at: #{attributes[:disabled_at]}, encrypted_serial: nil, type: 1>"
       )
     end


### PR DESCRIPTION
While debugging code backed by `StoreModel`, I had issues understanding some model attributes, as those that were more complex objects just printed the attribute's class and its memory address.

I saw something like:

```
=> #<Content::Text type: text, text: #<Content::Text::Base:0x000000011a9716f0>>
```

By contrast, the default Ruby `inspect` implementation calls `inspect` on all the object's instance variables:

```
=> #<OuterClass:0x0000000104ac87f8 @attribute=#<InnerClass:0x000000010466cf60 @text="string">>
```

Also, the strings are not quoted, making strings like `"nil"` and `"false"` show up as `nil` and `false`, which may lead to confusion.

This commit changes the `inspect` implementation to call `inspect` on the model attributes, fixing the issues stated above.