### PR TITLE
Fix accepts_nested_attributes_for with `allow_destroy: true` raising …

### DIFF
--- a/lib/store_model/nested_attributes.rb
+++ b/lib/store_model/nested_attributes.rb
@@ -84,7 +84,7 @@ module StoreModel
       def define_attr_accessor_for_destroy(association, options)
         return unless options&.dig(:allow_destroy)
 
-        attribute_types[association.to_s].model_klass.class_eval do
+        nested_attribute_type(association).model_klass.class_eval do
           attr_accessor :_destroy
         end
       end

--- a/spec/store_model/nested_attributes_spec.rb
+++ b/spec/store_model/nested_attributes_spec.rb
@@ -392,7 +392,7 @@ RSpec.describe StoreModel::NestedAttributes do
 
       context "when db is not connected" do
         subject do
-          model_class.accepts_nested_attributes_for(:suppliers)
+          model_class.accepts_nested_attributes_for(:suppliers, allow_destroy: true)
           model_class
         end
 


### PR DESCRIPTION
…error when database is not initialized or table for model doesnt exist