### PR TITLE
Manageable raising on invalid enum value

### DIFF
--- a/docs/enums.md
+++ b/docs/enums.md
@@ -67,3 +67,15 @@ review.archived_status? # => false
 review.comments_active? # => false
 review.comments_inactive? # => true
 ```
+
+You can use the `:raise_on_invalid_values` options when you need to allow the enum to accept invalid values. However, in this case you'll need to handle validation of the values manually:
+
+```ruby
+class Review
+  include StoreModel::Model
+
+  enum status: [:active, :archived], raise_on_invalid_values: false
+
+  validate_inclusion_of :status, in: ['active', 'archived']
+end
+```

--- a/lib/store_model/enum.rb
+++ b/lib/store_model/enum.rb
@@ -10,8 +10,7 @@ module StoreModel
     # @param kwargs [Object]
     def enum(name, values = nil, **kwargs)
       values ||= kwargs[:in] || kwargs
-      options = kwargs.slice(:_prefix, :_suffix, :default, :raise_on_invalid_values)
-                      .reverse_merge(raise_on_invalid_values: true)
+      options = retrieve_options(kwargs)
 
       ensure_hash(values).tap do |mapping|
         define_attribute(name, mapping, options)
@@ -24,6 +23,12 @@ module StoreModel
     end
 
     private
+
+    def retrieve_options(options)
+      default_options = { raise_on_invalid_values: true }
+      options.slice(:_prefix, :_suffix, :default, :raise_on_invalid_values)
+             .reverse_merge(default_options)
+    end
 
     def define_attribute(name, mapping, options)
       attribute name, cast_type(mapping, options[:raise_on_invalid_values]), default: options[:default]

--- a/lib/store_model/enum.rb
+++ b/lib/store_model/enum.rb
@@ -10,12 +10,13 @@ module StoreModel
     # @param kwargs [Object]
     def enum(name, values = nil, **kwargs)
       values ||= kwargs[:in] || kwargs
-      options = kwargs.slice(:_prefix, :_suffix, :default)
+      options = kwargs.slice(:_prefix, :_suffix, :default, :raise_on_invalid_values)
+                      .reverse_merge(raise_on_invalid_values: true)
 
       ensure_hash(values).tap do |mapping|
-        define_attribute(name, mapping, options[:default])
+        define_attribute(name, mapping, options)
         define_reader(name, mapping)
-        define_writer(name, mapping)
+        define_writer(name, mapping, options[:raise_on_invalid_values])
         define_method("#{name}_value") { attributes[name.to_s] }
         define_map_readers(name, mapping)
         define_predicate_methods(name, mapping, options)
@@ -24,16 +25,19 @@ module StoreModel
 
     private
 
-    def define_attribute(name, mapping, default)
-      attribute name, cast_type(mapping), default: default
+    def define_attribute(name, mapping, options)
+      attribute name, cast_type(mapping, options[:raise_on_invalid_values]), default: options[:default]
     end
 
     def define_reader(name, mapping)
-      define_method(name) { mapping.key(send("#{name}_value")).to_s }
+      define_method(name) do
+        raw_value = send("#{name}_value")
+        (mapping.key(raw_value) || raw_value).to_s
+      end
     end
 
-    def define_writer(name, mapping)
-      type = cast_type(mapping)
+    def define_writer(name, mapping, raise_on_invalid_values)
+      type = cast_type(mapping, raise_on_invalid_values)
       define_method("#{name}=") { |value| super type.cast_value(value) }
     end
 
@@ -50,8 +54,8 @@ module StoreModel
       singleton_class.alias_method(ActiveSupport::Inflector.pluralize(name), "#{name}_values")
     end
 
-    def cast_type(mapping)
-      StoreModel::Types::EnumType.new(mapping)
+    def cast_type(mapping, raise_on_invalid_values)
+      StoreModel::Types::EnumType.new(mapping, raise_on_invalid_values)
     end
 
     def ensure_hash(values)

--- a/lib/store_model/types/enum_type.rb
+++ b/lib/store_model/types/enum_type.rb
@@ -11,8 +11,9 @@ module StoreModel
       # @param mapping [Hash] mapping for enum values
       #
       # @return [StoreModel::Types::EnumType]
-      def initialize(mapping)
+      def initialize(mapping, raise_on_invalid_values)
         @mapping = mapping
+        @raise_on_invalid_values = raise_on_invalid_values
       end
 
       # Returns type
@@ -31,7 +32,7 @@ module StoreModel
         return if value.blank?
 
         case value
-        when String, Symbol then cast_symbol_value(value.to_sym)
+        when String, Symbol then cast_symbol_value(value)
         when Integer then cast_integer_value(value)
         else
           raise StoreModel::Types::CastError,
@@ -43,12 +44,12 @@ module StoreModel
       private
 
       def cast_symbol_value(value)
-        raise_invalid_value!(value) unless @mapping.key?(value.to_sym)
-        @mapping[value.to_sym]
+        raise_invalid_value!(value) if @raise_on_invalid_values && !@mapping.key?(value.to_sym)
+        @mapping[value.to_sym] || value
       end
 
       def cast_integer_value(value)
-        raise_invalid_value!(value) unless @mapping.value?(value)
+        raise_invalid_value!(value) if @raise_on_invalid_values && !@mapping.value?(value)
         value
       end
 

--- a/spec/store_model/enum_spec.rb
+++ b/spec/store_model/enum_spec.rb
@@ -88,11 +88,28 @@ RSpec.describe StoreModel::Model do
   context "when value is not in the list" do
     let(:value) { "undefined" }
 
-    it "raises exception" do
-      expect { subject.status = value }.to raise_error(
-        ArgumentError,
-        "invalid value '#{value}' is assigned"
-      )
+    context "when raise_on_invalid_values is true" do
+      it "raises exception" do
+        expect { subject.status = value }.to raise_error(
+          ArgumentError,
+          "invalid value '#{value}' is assigned"
+        )
+      end
+    end
+
+    context "when raise_on_invalid_values is false" do
+      let(:config_class) do
+        Class.new do
+          include StoreModel::Model
+
+          enum :status, in: { active: 1, archived: 0 }, raise_on_invalid_values: false
+        end
+      end
+
+      it "sets the value" do
+        subject.status = value
+        expect(subject.status).to eq(value)
+      end
     end
   end
 

--- a/spec/store_model/types/enum_type_spec.rb
+++ b/spec/store_model/types/enum_type_spec.rb
@@ -3,7 +3,8 @@
 require "spec_helper"
 
 RSpec.describe StoreModel::Types::EnumType do
-  let(:type) { described_class.new(active: 1, archived: 0) }
+  let(:type) { described_class.new({ active: 1, archived: 0 }, raise_on_invalid_values) }
+  let(:raise_on_invalid_values) { true }
 
   describe "#type" do
     subject { type.type }
@@ -22,11 +23,19 @@ RSpec.describe StoreModel::Types::EnumType do
       context "when value is not in the list" do
         let(:value) { "reactive" }
 
-        it "raises exception" do
-          expect { subject }.to raise_error(
-            ArgumentError,
-            "invalid value '#{value}' is assigned"
-          )
+        context "when raise_on_invalid_values is true" do
+          it "raises exception" do
+            expect { subject }.to raise_error(
+              ArgumentError,
+              "invalid value '#{value}' is assigned"
+            )
+          end
+        end
+
+        context "when raise_on_invalid_values is false" do
+          let(:raise_on_invalid_values) { false }
+
+          it { is_expected.to eq(value) }
         end
       end
     end
@@ -39,11 +48,19 @@ RSpec.describe StoreModel::Types::EnumType do
       context "when value is not in the list" do
         let(:value) { :reactive }
 
-        it "raises exception" do
-          expect { subject }.to raise_error(
-            ArgumentError,
-            "invalid value '#{value}' is assigned"
-          )
+        context "when raise_on_invalid_values is true" do
+          it "raises exception" do
+            expect { subject }.to raise_error(
+              ArgumentError,
+              "invalid value '#{value}' is assigned"
+            )
+          end
+        end
+
+        context "when raise_on_invalid_values is false" do
+          let(:raise_on_invalid_values) { false }
+
+          it { is_expected.to eq(value) }
         end
       end
     end
@@ -56,11 +73,19 @@ RSpec.describe StoreModel::Types::EnumType do
       context "when value is not in the list" do
         let(:value) { 5 }
 
-        it "raises exception" do
-          expect { subject }.to raise_error(
-            ArgumentError,
-            "invalid value '#{value}' is assigned"
-          )
+        context "when raise_on_invalid_values is true" do
+          it "raises exception" do
+            expect { subject }.to raise_error(
+              ArgumentError,
+              "invalid value '#{value}' is assigned"
+            )
+          end
+        end
+
+        context "when raise_on_invalid_values is false" do
+          let(:raise_on_invalid_values) { false }
+
+          it { is_expected.to eq(value) }
         end
       end
     end


### PR DESCRIPTION
Hey, just recently I was working on an API where I had to add a validation on enum attributes. Unfortunately, there were no other validation mechanisms before passing the parameters to the model. Therefore, the `store_model` instance raised an error every time a wrong value was passed to the API.

I checked the `ActiveRecord::Enum` behavior and found, that they have a `validate: boolean` parameter, that turns off the raising an exception and adds a validation for the field to the model. I'm not sure if we should interfere with the model, so here is my implementation of the enum that supports a new parameter `raise_on_invalid_values: boolean (default: true)` just so we turn off the check.

Not sure if it's a good idea to update the type, or maybe it would be better to create another type that'd inherit from `EnumType`. Let me know what you think about this.