### PR TITLE
Update documentation to reflect behavior of `serialize_unknown_attributes` in v2.1.1+

### DIFF
--- a/docs/unknown_attributes.md
+++ b/docs/unknown_attributes.md
@@ -46,4 +46,4 @@ configuration = Configuration.to_type.cast_value(color: "red", archived: true)
 configuration.as_json(serialize_unknown_attributes: true) # => {"color": "red", "archived": true}
 ```
 
-In any case unknown attributes are always stored in the database.
+Prior to version 2.1.1, unknown attributes are always stored in the database. However, starting from version 2.1.1, if `serialize_unknown_attributes` is set to `false`, unknown attributes will not be stored in the database.


### PR DESCRIPTION
While validating updates to the StoreModel, I encountered a change in behavior concerning the handling of unknown attributes during database storage operations. Specifically, I noticed that starting from version 2.1.1, the `serialize_unknown_attributes` option, when set to `false`, prevents unknown attributes from being stored in the database. Hence, I've updated the documentation.