### PR TITLE
Optional parent tracking

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -29,6 +29,8 @@ jobs:
           "gemfiles/rails_7_0.gemfile"
         ]
 
+        # TODO: ENV ENABLE_PARAM_ASSIGNMENT set to true/false
+
         allow_failures:
           - false
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -16,7 +16,7 @@ jobs:
       CI: true
       ALLOW_FAILURES: "${{ matrix.allow_failures }}"
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
-      ENABLE_PARAM_ASSIGNMENT: "${{ matrix.enable_param_assignment }}"
+      ENABLE_PARENT_ASSIGNMENT: "${{ matrix.enable_parent_assignment }}"
 
     strategy:
       fail-fast: false
@@ -30,7 +30,7 @@ jobs:
           "gemfiles/rails_7_0.gemfile"
         ]
 
-        enable_param_assignment: ["true", "false"]
+        enable_parent_assignment: ["true", "false"]
 
         allow_failures:
           - false

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -16,6 +16,7 @@ jobs:
       CI: true
       ALLOW_FAILURES: "${{ matrix.allow_failures }}"
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+      ENABLE_PARAM_ASSIGNMENT: "${{ matrix.enable_param_assignment }}"
 
     strategy:
       fail-fast: false
@@ -29,7 +30,7 @@ jobs:
           "gemfiles/rails_7_0.gemfile"
         ]
 
-        # TODO: ENV ENABLE_PARAM_ASSIGNMENT set to true/false
+        enable_param_assignment: ["true", "false"]
 
         allow_failures:
           - false

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ end
 4. [One of](./docs/one_of.md)
 4. [Alternatives](./docs/alternatives.md)
 5. [Defining custom types](./docs/defining_custom_types.md)
+6. [Disabling Parent Tracking](./docs/enable_parent_assignment.md)
 
 ## Credits
 

--- a/docs/enable_parent_assignment.md
+++ b/docs/enable_parent_assignment.md
@@ -1,0 +1,26 @@
+## Disabling Parent Tracking and Active Record extensions
+
+`store_model` tracks the parent object of models using `StoreModel::Model`.
+This allows your store model, to know where it got assigned.
+
+```ruby
+class Configuration
+  include StoreModel::Model
+
+  attribute :model, :string
+end
+
+class Product < ApplicationRecord
+  attribute :configuration, Configuration.to_type
+end
+
+product = Product.first
+product.configuration.parent # returns the `product` object
+```
+
+This behavior is achieved via Active Record extensions and it can be disabled globally:
+
+```ruby
+# config/initializers/store_model.rb
+StoreModel.config.enable_parent_assignment = false
+```

--- a/lib/store_model/configuration.rb
+++ b/lib/store_model/configuration.rb
@@ -15,10 +15,13 @@ module StoreModel
     # @return [Boolean]
     attr_accessor :serialize_unknown_attributes
 
-    # Controls if the result of `as_json` will serialize enum fiels using `as_json`
+    # Controls if the result of `as_json` will serialize enum fields using `as_json`
     # @return [Boolean]
     attr_accessor :serialize_enums_using_as_json
 
+    # Controls if parent tracking functionality is enabled.
+    # Default: true
+    # @return [Boolean]
     attr_accessor :enable_parent_assignment
 
     def initialize

--- a/lib/store_model/configuration.rb
+++ b/lib/store_model/configuration.rb
@@ -19,8 +19,11 @@ module StoreModel
     # @return [Boolean]
     attr_accessor :serialize_enums_using_as_json
 
+    attr_accessor :enable_parent_assignment
+
     def initialize
       @serialize_unknown_attributes = true
+      @enable_parent_assignment = true
     end
   end
 end

--- a/lib/store_model/railtie.rb
+++ b/lib/store_model/railtie.rb
@@ -5,15 +5,15 @@ require "store_model/ext/active_record/base"
 
 module StoreModel # :nodoc:
   class Railtie < Rails::Railtie # :nodoc:
+
     config.to_prepare do |_app|
-      # Disable parent tracking functionality
-      # which patches ActiveRecord and ActiveModel
-      # functionality. 
-      #
-      # ActiveSupport.on_load(:active_record) do
-      #   ActiveModel::Attributes.prepend(Attributes)
-      #   prepend(Base)
-      # end
+      ActiveSupport.on_load(:active_record) do
+        if StoreModel.config.enable_parent_assignment
+          ActiveModel::Attributes.prepend(Attributes)
+          prepend(Base)
+        end
+      end
     end
+
   end
 end

--- a/lib/store_model/railtie.rb
+++ b/lib/store_model/railtie.rb
@@ -6,10 +6,14 @@ require "store_model/ext/active_record/base"
 module StoreModel # :nodoc:
   class Railtie < Rails::Railtie # :nodoc:
     config.to_prepare do |_app|
-      ActiveSupport.on_load(:active_record) do
-        ActiveModel::Attributes.prepend(Attributes)
-        prepend(Base)
-      end
+      # Disable parent tracking functionality
+      # which patches ActiveRecord and ActiveModel
+      # functionality. 
+      #
+      # ActiveSupport.on_load(:active_record) do
+      #   ActiveModel::Attributes.prepend(Attributes)
+      #   prepend(Base)
+      # end
     end
   end
 end

--- a/lib/store_model/railtie.rb
+++ b/lib/store_model/railtie.rb
@@ -5,7 +5,6 @@ require "store_model/ext/active_record/base"
 
 module StoreModel # :nodoc:
   class Railtie < Rails::Railtie # :nodoc:
-
     config.to_prepare do |_app|
       ActiveSupport.on_load(:active_record) do
         if StoreModel.config.enable_parent_assignment
@@ -14,6 +13,5 @@ module StoreModel # :nodoc:
         end
       end
     end
-
   end
 end

--- a/spec/dummy/config/initializers/enable_parent_assignment.rb
+++ b/spec/dummy/config/initializers/enable_parent_assignment.rb
@@ -1,12 +1,15 @@
+# frozen_string_literal: true
+
 if ENV.key?("ENABLE_PARENT_ASSIGNMENT")
-  enable_parent_assignment = case ENV.fetch("ENABLE_PARENT_ASSIGNMENT").strip.downcase
-  when "true"
-    true
-  when "false"
-    false
-  else
-    raise "Wrong ENV['ENABLE_PARENT_ASSIGNMENT'] value: #{ENV.fetch("ENABLE_PARENT_ASSIGNMENT")}"
-  end
+  value = ENV.fetch("ENABLE_PARENT_ASSIGNMENT").strip.downcase
+  enable_parent_assignment = case value
+                             when "true"
+                               true
+                             when "false"
+                               false
+                             else
+                               raise "Wrong ENV['ENABLE_PARENT_ASSIGNMENT'] value: #{value}"
+                             end
   StoreModel.config.enable_parent_assignment = enable_parent_assignment
 end
 ENABLE_PARENT_ASSIGNMENT = StoreModel.config.enable_parent_assignment

--- a/spec/dummy/config/initializers/enable_parent_assignment.rb
+++ b/spec/dummy/config/initializers/enable_parent_assignment.rb
@@ -1,0 +1,12 @@
+if ENV.key?("ENABLE_PARAM_ASSIGNMENT")
+  enable_parent_assignment = case ENV.fetch("ENABLE_PARAM_ASSIGNMENT")
+  when "true"
+    true
+  when "false"
+    false
+  else
+    raise "Wrong ENV['ENABLE_PARAM_ASSIGNMENT'] value: #{ENV.fetch("ENABLE_PARAM_ASSIGNMENT")}"
+  end
+  StoreModel.config.enable_parent_assignment = enable_parent_assignment
+end
+ENABLE_PARAM_ASSIGNMENT = StoreModel.config.enable_parent_assignment

--- a/spec/dummy/config/initializers/enable_parent_assignment.rb
+++ b/spec/dummy/config/initializers/enable_parent_assignment.rb
@@ -1,5 +1,5 @@
 if ENV.key?("ENABLE_PARENT_ASSIGNMENT")
-  enable_parent_assignment = case ENV.fetch("ENABLE_PARENT_ASSIGNMENT")
+  enable_parent_assignment = case ENV.fetch("ENABLE_PARENT_ASSIGNMENT").strip.downcase
   when "true"
     true
   when "false"

--- a/spec/dummy/config/initializers/enable_parent_assignment.rb
+++ b/spec/dummy/config/initializers/enable_parent_assignment.rb
@@ -1,12 +1,12 @@
-if ENV.key?("ENABLE_PARAM_ASSIGNMENT")
-  enable_parent_assignment = case ENV.fetch("ENABLE_PARAM_ASSIGNMENT")
+if ENV.key?("ENABLE_PARENT_ASSIGNMENT")
+  enable_parent_assignment = case ENV.fetch("ENABLE_PARENT_ASSIGNMENT")
   when "true"
     true
   when "false"
     false
   else
-    raise "Wrong ENV['ENABLE_PARAM_ASSIGNMENT'] value: #{ENV.fetch("ENABLE_PARAM_ASSIGNMENT")}"
+    raise "Wrong ENV['ENABLE_PARENT_ASSIGNMENT'] value: #{ENV.fetch("ENABLE_PARENT_ASSIGNMENT")}"
   end
   StoreModel.config.enable_parent_assignment = enable_parent_assignment
 end
-ENABLE_PARAM_ASSIGNMENT = StoreModel.config.enable_parent_assignment
+ENABLE_PARENT_ASSIGNMENT = StoreModel.config.enable_parent_assignment

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ RSpec.configure do |config|
   config.after(:each) do
     StoreModel.remove_instance_variable(:@config) if StoreModel.instance_variable_defined?(:@config)
     StoreModel.config.serialize_enums_using_as_json = true
-    StoreModel.config.enable_parent_assignment = ENABLE_PARAM_ASSIGNMENT
+    StoreModel.config.enable_parent_assignment = ENABLE_PARENT_ASSIGNMENT
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ RSpec.configure do |config|
   config.after(:each) do
     StoreModel.remove_instance_variable(:@config) if StoreModel.instance_variable_defined?(:@config)
     StoreModel.config.serialize_enums_using_as_json = true
+    StoreModel.config.enable_parent_assignment = ENABLE_PARAM_ASSIGNMENT
   end
 end
 

--- a/spec/store_model/configuration_spec.rb
+++ b/spec/store_model/configuration_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe StoreModel::Configuration do
+  subject(:configuration) { described_class.new }
+
+  specify "parent assignment is enabled by default" do
+    expect(configuration.enable_parent_assignment).to eq(true)
+
+    configuration.enable_parent_assignment = false
+    expect(configuration.enable_parent_assignment).to eq(false)
+  end
+end

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -181,9 +181,6 @@ RSpec.describe StoreModel::Model do
           expect(subject.configuration.parent).to eq(subject)
         else
           expect(subject.configuration.parent).to be_nil
-
-          # TODO: Remove me!
-          expect("Verify correct github workflow").to eq("This should fail too see ENV ENABLE_PARENT_ASSIGNMENT working")
         end
 
       end

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -177,12 +177,21 @@ RSpec.describe StoreModel::Model do
 
     shared_examples "for singular type" do
       it "returns parent instance" do
-        expect(subject.configuration.parent).to eq(subject)
+        if StoreModel.config.enable_parent_assignment
+          expect(subject.configuration.parent).to eq(subject)
+        else
+          expect(subject.configuration.parent).to be_nil
+        end
+        
       end
 
       it "updates parent after assignment" do
         subject.configuration = configuration
-        expect(configuration.parent).to eq(subject)
+        if StoreModel.config.enable_parent_assignment
+          expect(configuration.parent).to eq(subject)
+        else
+          expect(configuration.parent).to be_nil
+        end
       end
 
       it "uses defaults" do
@@ -201,7 +210,11 @@ RSpec.describe StoreModel::Model do
 
       it "updates parent after assignment" do
         subject.configuration = [configuration]
-        expect(configuration.parent).to eq(subject)
+        if StoreModel.config.enable_parent_assignment
+          expect(configuration.parent).to eq(subject)
+        else
+          expect(configuration.parent).to be_nil
+        end
       end
     end
 

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -192,7 +192,11 @@ RSpec.describe StoreModel::Model do
 
     shared_examples "for array type" do
       it "returns parent instance" do
-        expect(subject.configuration[0].parent).to eq(subject)
+        if StoreModel.config.enable_parent_assignment
+          expect(subject.configuration[0].parent).to eq(subject)
+        else
+          expect(subject.configuration[0].parent).to be_nil
+        end
       end
 
       it "updates parent after assignment" do

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -182,7 +182,6 @@ RSpec.describe StoreModel::Model do
         else
           expect(subject.configuration.parent).to be_nil
         end
-
       end
 
       it "updates parent after assignment" do

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -181,8 +181,11 @@ RSpec.describe StoreModel::Model do
           expect(subject.configuration.parent).to eq(subject)
         else
           expect(subject.configuration.parent).to be_nil
+
+          # TODO: Remove me!
+          expect("Verify correct github workflow").to eq("This should fail too see ENV ENABLE_PARENT_ASSIGNMENT working")
         end
-        
+
       end
 
       it "updates parent after assignment" do


### PR DESCRIPTION
* Optional parent tracking functionality. Can be disabled with settings.
* Docs updated.
* Specs changed to verify both approaches, including github actions workflow.

## TODO

* [x] Remove TODO from code once GH workflow is approved and verified to be working correctly (failing for ENABLE_PARENT_ASSIGNMENT=false now)

```
          # TODO: Remove me!
          expect("Verify correct github workflow").to eq("This should fail too see ENV ENABLE_PARENT_ASSIGNMENT working")
```

Fixes #167 