### PR TITLE
Restore behavior to always store unknown attributes in the database

### DIFF
--- a/docs/unknown_attributes.md
+++ b/docs/unknown_attributes.md
@@ -46,4 +46,4 @@ configuration = Configuration.to_type.cast_value(color: "red", archived: true)
 configuration.as_json(serialize_unknown_attributes: true) # => {"color": "red", "archived": true}
 ```
 
-Prior to version 2.1.1, unknown attributes are always stored in the database. However, starting from version 2.1.1, if `serialize_unknown_attributes` is set to `false`, unknown attributes will not be stored in the database.
+In any case unknown attributes are always stored in the database.

--- a/lib/store_model/types/one.rb
+++ b/lib/store_model/types/one.rb
@@ -47,7 +47,7 @@ module StoreModel
       def serialize(value)
         case value
         when @model_klass, Hash
-          ActiveSupport::JSON.encode(value)
+          ActiveSupport::JSON.encode(value, serialize_unknown_attributes: true)
         else
           super
         end

--- a/spec/store_model/types/many_polymorphic_spec.rb
+++ b/spec/store_model/types/many_polymorphic_spec.rb
@@ -9,11 +9,19 @@ RSpec.describe StoreModel::Types::ManyPolymorphic do
     [
       {
         color: "red",
-        disabled_at: Time.new(2019, 2, 22, 12, 30).utc
+        model: nil,
+        active: true,
+        disabled_at: Time.new(2019, 2, 22, 12, 30).utc,
+        encrypted_serial: nil,
+        type: "left"
       },
       {
         color: "green",
-        disabled_at: Time.new(2019, 3, 12, 8, 10).utc
+        model: nil,
+        active: false,
+        disabled_at: Time.new(2019, 3, 12, 8, 10).utc,
+        encrypted_serial: nil,
+        type: "right"
       }
     ]
   end
@@ -194,6 +202,28 @@ RSpec.describe StoreModel::Types::ManyPolymorphic do
     context "when String is passed" do
       let(:value) { ActiveSupport::JSON.encode(attributes_array) }
       include_examples "serialize examples"
+    end
+
+    context "when Array of instances is passed" do
+      let(:value) { attributes_array.map { |attrs| Configuration.new(attrs) } }
+      include_examples "serialize examples"
+
+      context "with unknown attributes" do
+        before do
+          value.each_with_index { |v, index| v.unknown_attributes[:archived] = index.even? }
+        end
+
+        [true, false].each do |serialize_unknown_attributes|
+          it "always includes unknown attributes regardless of the serialize_unknown_attributes option" do
+            StoreModel.config.serialize_unknown_attributes = serialize_unknown_attributes
+            expect(subject).to eq(
+              attributes_array.map.with_index do |attrs, index|
+                attrs.merge(value[index].unknown_attributes)
+              end.to_json
+            )
+          end
+        end
+      end
     end
   end
 end

--- a/spec/store_model/types/one_polymorphic_spec.rb
+++ b/spec/store_model/types/one_polymorphic_spec.rb
@@ -249,6 +249,19 @@ RSpec.describe StoreModel::Types::OnePolymorphic do
     context "when Configuration instance is passed" do
       let(:value) { Configuration.new(attributes) }
       include_examples "serialize examples"
+
+      context "with unknown attributes" do
+        before do
+          value.unknown_attributes[:archived] = true
+        end
+
+        [true, false].each do |serialize_unknown_attributes|
+          it "always includes unknown attributes regardless of the serialize_unknown_attributes option" do
+            StoreModel.config.serialize_unknown_attributes = serialize_unknown_attributes
+            expect(subject).to eq(attributes.merge(value.unknown_attributes).to_json)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/store_model/types/one_spec.rb
+++ b/spec/store_model/types/one_spec.rb
@@ -198,6 +198,19 @@ RSpec.describe StoreModel::Types::One do
       it { is_expected.to be_a(String) }
 
       it("is equal to attributes") { is_expected.to eq(attributes.merge(type: nil).to_json) }
+
+      context "with unknown attributes" do
+        before do
+          value.unknown_attributes[:archived] = true
+        end
+
+        [true, false].each do |serialize_unknown_attributes|
+          it "always includes unknown attributes regardless of the serialize_unknown_attributes option" do
+            StoreModel.config.serialize_unknown_attributes = serialize_unknown_attributes
+            expect(subject).to eq(attributes.merge(type: nil, **value.unknown_attributes).to_json)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Our application uses StoreModel with the `serialize_unknown_attributes` option set to `false`.

Previously, StoreModel versions prior to 2.1.1 always stored unknown attributes in the database. However, now, unknown attributes are not stored unless the `serialize_unknown_attributes` option is set to `true`. This change was inconvenient for us; therefore, we want to restore the behavior of storing unknown attributes in the database, regardless of the setting of the `serialize_unknown_attributes` option.

The fix was straightforward. Furthermore, to ensure this behavior does not break, I have improved the tests for the `serialize` method in each `Type` class.

However, this change will again alter the behavior of storing unknown attributes in the database. I considered adding an option to choose whether to store unknown attributes or not. The challenge, then, is deciding what the default value for this new option should be. Considering current users who have the `serialize_unknown_attributes` option enabled, the default should logically be to store. Ultimately, this would amount to a similar breaking change.

Nevertheless, it simply restores the behavior of the previous version.