### PR TITLE
Fix issue with serialization options not applied to nested objects

### DIFF
--- a/lib/store_model/types/many_base.rb
+++ b/lib/store_model/types/many_base.rb
@@ -40,7 +40,11 @@ module StoreModel
       def serialize(value)
         case value
         when Array
-          ActiveSupport::JSON.encode(value, serialize_unknown_attributes: true)
+          return ActiveSupport::JSON.encode(value) unless value.all? { |v| v.is_a?(StoreModel::Model) }
+
+          ActiveSupport::JSON.encode(value,
+                                     serialize_unknown_attributes: value.first.serialize_unknown_attributes?,
+                                     serialize_enums_using_as_json: value.first.serialize_enums_using_as_json?)
         else
           super
         end

--- a/lib/store_model/types/one.rb
+++ b/lib/store_model/types/one.rb
@@ -46,8 +46,12 @@ module StoreModel
       # @return [String] serialized value
       def serialize(value)
         case value
-        when @model_klass, Hash
-          ActiveSupport::JSON.encode(value, serialize_unknown_attributes: true)
+        when @model_klass
+          ActiveSupport::JSON.encode(value,
+                                     serialize_unknown_attributes: value.serialize_unknown_attributes?,
+                                     serialize_enums_using_as_json: value.serialize_enums_using_as_json?)
+        when Hash
+          ActiveSupport::JSON.encode(value)
         else
           super
         end

--- a/lib/store_model/types/one_polymorphic.rb
+++ b/lib/store_model/types/one_polymorphic.rb
@@ -52,7 +52,15 @@ module StoreModel
       def serialize(value)
         return super unless value.is_a?(Hash) || implements_model?(value.class)
 
-        ActiveSupport::JSON.encode(value, serialize_unknown_attributes: true)
+        if value.is_a?(StoreModel::Model)
+          ActiveSupport::JSON.encode(
+            value,
+            serialize_unknown_attributes: value.serialize_unknown_attributes?,
+            serialize_enums_using_as_json: value.serialize_enums_using_as_json?
+          )
+        else
+          ActiveSupport::JSON.encode(value)
+        end
       end
 
       protected

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,11 @@ RSpec.configure do |config|
   config.formatter = :documentation
   config.color = true
 
+  config.before(:all) do
+    # Set to `true` because it is initially `nil` in the first test.
+    StoreModel.config.serialize_enums_using_as_json = true
+  end
+
   config.after(:each) do
     StoreModel.remove_instance_variable(:@config) if StoreModel.instance_variable_defined?(:@config)
     StoreModel.config.serialize_enums_using_as_json = true

--- a/spec/store_model/types/many_polymorphic_spec.rb
+++ b/spec/store_model/types/many_polymorphic_spec.rb
@@ -223,6 +223,48 @@ RSpec.describe StoreModel::Types::ManyPolymorphic do
             )
           end
         end
+
+        context "when serialize_unknown_attributes attribute of instances is set to true" do
+          it "includes unknown attributes by overriding the globally configured behavior" do
+            value.each { |v| v.serialize_unknown_attributes = true }
+            expect(subject).to eq(
+              attributes_array.map.with_index do |attrs, index|
+                attrs.merge(value[index].unknown_attributes)
+              end.to_json
+            )
+          end
+        end
+
+        context "when serialize_unknown_attributes attribute of instances is set to false" do
+          it "does not include unknown attributes by overriding the globally configured behavior" do
+            value.each { |v| v.serialize_unknown_attributes = false }
+            expect(subject).to eq(attributes_array.to_json)
+          end
+        end
+      end
+
+      context "with enums" do
+        context "when serialize_enums_using_as_json attribute of instances is set to true" do
+          it "serializes enums by overriding the globally configured behavior" do
+            value.each { |v| v.serialize_enums_using_as_json = true }
+            expect(subject).to eq(
+              attributes_array.map do |attrs|
+                attrs.merge(type: attrs[:type])
+              end.to_json
+            )
+          end
+        end
+
+        context "when serialize_enums_using_as_json attribute of instances is set to false" do
+          it "does not serialize enums by overriding the globally configured behavior" do
+            value.each { |v| v.serialize_enums_using_as_json = false }
+            expect(subject).to eq(
+              attributes_array.map do |attrs|
+                attrs.merge(type: Configuration.types[attrs[:type].to_sym])
+              end.to_json
+            )
+          end
+        end
       end
     end
   end

--- a/spec/store_model/types/many_spec.rb
+++ b/spec/store_model/types/many_spec.rb
@@ -190,6 +190,48 @@ RSpec.describe StoreModel::Types::Many do
             )
           end
         end
+
+        context "when serialize_unknown_attributes attribute of instances is set to true" do
+          it "includes unknown attributes by overriding the globally configured behavior" do
+            value.each { |v| v.serialize_unknown_attributes = true }
+            expect(subject).to eq(
+              attributes_array.map.with_index do |attrs, index|
+                attrs.merge(value[index].unknown_attributes)
+              end.to_json
+            )
+          end
+        end
+
+        context "when serialize_unknown_attributes attribute of instances is set to false" do
+          it "does not include unknown attributes by overriding the globally configured behavior" do
+            value.each { |v| v.serialize_unknown_attributes = false }
+            expect(subject).to eq(attributes_array.to_json)
+          end
+        end
+      end
+
+      context "with enums" do
+        context "when serialize_enums_using_as_json attribute of instances is set to true" do
+          it "serializes enums by overriding the globally configured behavior" do
+            value.each { |v| v.serialize_enums_using_as_json = true }
+            expect(subject).to eq(
+              attributes_array.map do |attrs|
+                attrs.merge(type: attrs[:type])
+              end.to_json
+            )
+          end
+        end
+
+        context "when serialize_enums_using_as_json attribute of instances is set to false" do
+          it "does not serialize enums by overriding the globally configured behavior" do
+            value.each { |v| v.serialize_enums_using_as_json = false }
+            expect(subject).to eq(
+              attributes_array.map do |attrs|
+                attrs.merge(type: Configuration.types[attrs[:type].to_sym])
+              end.to_json
+            )
+          end
+        end
       end
     end
   end

--- a/spec/store_model/types/one_polymorphic_spec.rb
+++ b/spec/store_model/types/one_polymorphic_spec.rb
@@ -261,6 +261,36 @@ RSpec.describe StoreModel::Types::OnePolymorphic do
             expect(subject).to eq(attributes.merge(value.unknown_attributes).to_json)
           end
         end
+
+        context "when serialize_unknown_attributes attribute of instance is set to true" do
+          it "includes unknown attributes by overriding the globally configured behavior" do
+            value.serialize_unknown_attributes = true
+            expect(subject).to eq(attributes.merge(value.unknown_attributes).to_json)
+          end
+        end
+
+        context "when serialize_unknown_attributes attribute of instance is set to false" do
+          it "does not include unknown attributes by overriding the globally configured behavior" do
+            value.serialize_unknown_attributes = false
+            expect(subject).to eq(attributes.to_json)
+          end
+        end
+      end
+
+      context "with enums" do
+        context "when serialize_enums_using_as_json attribute of instance is set to true" do
+          it "serializes enums by overriding the globally configured behavior" do
+            value.serialize_enums_using_as_json = true
+            expect(subject).to eq(attributes.merge(type: "left").to_json)
+          end
+        end
+
+        context "when serialize_enums_using_as_json attribute of instance is set to false" do
+          it "does not serialize enums by overriding the globally configured behavior" do
+            value.serialize_enums_using_as_json = false
+            expect(subject).to eq(attributes.merge(type: 1).to_json)
+          end
+        end
       end
     end
   end

--- a/spec/store_model/types/one_spec.rb
+++ b/spec/store_model/types/one_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe StoreModel::Types::One do
       model: nil,
       active: false,
       disabled_at: Time.new(2019, 2, 22, 12, 30).utc,
-      encrypted_serial: nil
+      encrypted_serial: nil,
+      type: "left"
     }
   end
 
@@ -197,7 +198,7 @@ RSpec.describe StoreModel::Types::One do
 
       it { is_expected.to be_a(String) }
 
-      it("is equal to attributes") { is_expected.to eq(attributes.merge(type: nil).to_json) }
+      it("is equal to attributes") { is_expected.to eq(attributes.to_json) }
 
       context "with unknown attributes" do
         before do
@@ -207,7 +208,37 @@ RSpec.describe StoreModel::Types::One do
         [true, false].each do |serialize_unknown_attributes|
           it "always includes unknown attributes regardless of the serialize_unknown_attributes option" do
             StoreModel.config.serialize_unknown_attributes = serialize_unknown_attributes
-            expect(subject).to eq(attributes.merge(type: nil, **value.unknown_attributes).to_json)
+            expect(subject).to eq(attributes.merge(value.unknown_attributes).to_json)
+          end
+        end
+
+        context "when serialize_unknown_attributes attribute of instance is set to true" do
+          it "includes unknown attributes by overriding the globally configured behavior" do
+            value.serialize_unknown_attributes = true
+            expect(subject).to eq(attributes.merge(value.unknown_attributes).to_json)
+          end
+        end
+
+        context "when serialize_unknown_attributes attribute of instance is set to false" do
+          it "does not include unknown attributes by overriding the globally configured behavior" do
+            value.serialize_unknown_attributes = false
+            expect(subject).to eq(attributes.to_json)
+          end
+        end
+      end
+
+      context "with enums" do
+        context "when serialize_enums_using_as_json attribute of instance is set to true" do
+          it "serializes enums by overriding the globally configured behavior" do
+            value.serialize_enums_using_as_json = true
+            expect(subject).to eq(attributes.merge(type: "left").to_json)
+          end
+        end
+
+        context "when serialize_enums_using_as_json attribute of instance is set to false" do
+          it "does not serialize enums by overriding the globally configured behavior" do
+            value.serialize_enums_using_as_json = false
+            expect(subject).to eq(attributes.merge(type: 1).to_json)
           end
         end
       end


### PR DESCRIPTION
In the current latest version 2.4.0, I noticed that serialization options are not applied to nested objects. For example, when specifying the `serialize_enums_using_as_json` option in the `as_json` method, it behaves as follows:

```ruby
StoreModel.config.serialize_enums_using_as_json = false

class Message
  include StoreModel::Model

  attribute :child, to_type

  enum :status, in: { unread: 0, read: 1 }
end

message = Message.new(status: "read", child: { status: "unread" })
message.as_json(
  serialize_enums_using_as_json: true
) # => { "child" => { "child" => nil, "status" => 0 }, "status" => "read" }
```

The same issue occurs with the `serialize_unknown_attributes` option.

This problem seems to arise because the `as_json` method serializes nested objects recursively; however, the serialization options are not passed down to the nested objects.

I resolved this issue by storing the serialization options as attributes in the `StoreModel::Model` object. This ensures that the options are correctly inherited by nested objects during serialization.

I would appreciate your feedback on this solution.