### PR TITLE
Update enums.md docs to reflect enum argument order when `raise_on_invalid_values` is set

### DIFF
--- a/docs/enums.md
+++ b/docs/enums.md
@@ -74,7 +74,7 @@ You can use the `:raise_on_invalid_values` options when you need to allow the en
 class Review
   include StoreModel::Model
 
-  enum status: [:active, :archived], raise_on_invalid_values: false
+  enum :status, [:active, :archived], raise_on_invalid_values: false
 
   validate_inclusion_of :status, in: ['active', 'archived']
 end


### PR DESCRIPTION
In reading the doc additions for [PR 164](https://github.com/DmitryTsepelev/store_model/pull/164/files#diff-14ac46a6a99731e4b04cb07dfce19f325ecbb4d65c2a42f00b7af1abfdeb2ed7R77) (Manageable raising on invalid enum value) the example would throw an ArgumentError with 

```
`enum': wrong number of arguments (given 0, expected 1..2) (ArgumentError)
```

This was due to how `enum` was being called in the example. This PR updates the docs the reflect the right method arguments. 