### PR TITLE
Fixed issue for empty nested array

### DIFF
--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -246,7 +246,7 @@ module StoreModel
     end
 
     def serialize_array_attribute(array)
-      return array.as_json unless array.all? { |value| value.is_a?(StoreModel::Model) }
+      return array.as_json unless array.any? && array.all? { |value| value.is_a?(StoreModel::Model) }
 
       array.as_json(
         serialize_unknown_attributes: array.first.serialize_unknown_attributes?,

--- a/spec/store_model/nested_attributes_spec.rb
+++ b/spec/store_model/nested_attributes_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe StoreModel::NestedAttributes do
               unknown: "nested array unknown"
             }
           ],
+          nested_empty_array: [],
           status: "active",
           unknown: "unknown" }
       end
@@ -123,6 +124,7 @@ RSpec.describe StoreModel::NestedAttributes do
               unknown: "nested array unknown"
             }
           ],
+          nested_empty_array: [],
           status: "active",
           unknown: "unknown" }
       end
@@ -144,6 +146,16 @@ RSpec.describe StoreModel::NestedAttributes do
           Anything.where(id: record.id).select("id, json_extract(store,'$.nested.non_enc_val')").to_sql
         ).first
         expect(very_nested_value).to eq([record.id, "nested public"])
+      end
+
+      describe "empty nested array" do
+        it "persists empty nested array" do
+          record.save
+          query = Anything.where(id: record.id).select(:store).to_sql
+          persisted_store = JSON.parse(ActiveRecord::Base.connection.query(query)[0][0])
+
+          expect(persisted_store["nested_array"]).to eq([])
+        end
       end
 
       describe "unknown attributes in nested objects" do

--- a/spec/store_model/nested_attributes_spec.rb
+++ b/spec/store_model/nested_attributes_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe StoreModel::NestedAttributes do
           attribute :non_enc_val
           attribute :nested, NestedStore.to_type
           attribute :nested_array, NestedStore.to_array_type
+          attribute :empty_nested_array, NestedStore.to_array_type, default: []
 
           enum :status, in: { active: 1, inactive: 2, archived: 3 }
         end
@@ -102,7 +103,7 @@ RSpec.describe StoreModel::NestedAttributes do
               unknown: "nested array unknown"
             }
           ],
-          nested_empty_array: [],
+          empty_nested_array: [],
           status: "active",
           unknown: "unknown" }
       end
@@ -124,7 +125,7 @@ RSpec.describe StoreModel::NestedAttributes do
               unknown: "nested array unknown"
             }
           ],
-          nested_empty_array: [],
+          empty_nested_array: [],
           status: "active",
           unknown: "unknown" }
       end
@@ -154,7 +155,7 @@ RSpec.describe StoreModel::NestedAttributes do
           query = Anything.where(id: record.id).select(:store).to_sql
           persisted_store = JSON.parse(ActiveRecord::Base.connection.query(query)[0][0])
 
-          expect(persisted_store["nested_array"]).to eq([])
+          expect(persisted_store["empty_nested_array"]).to eq([])
         end
       end
 


### PR DESCRIPTION
After the introduction of #171, I found an issue with my nested model containing an array with no elements in it (due to `default: []`).

This PR first checks if the array is empty, before validating if all values are `StoreModel::Model` objects.