### PR TITLE
fix serializing for array type attributes

### DIFF
--- a/lib/store_model/types/many_base.rb
+++ b/lib/store_model/types/many_base.rb
@@ -40,7 +40,7 @@ module StoreModel
       def serialize(value)
         case value
         when Array
-          return ActiveSupport::JSON.encode(value) unless value.all? { |v| v.is_a?(StoreModel::Model) }
+          return ActiveSupport::JSON.encode(value) unless value.any? && value.all? { |v| v.is_a?(StoreModel::Model) }
 
           ActiveSupport::JSON.encode(value,
                                      serialize_unknown_attributes: value.first.serialize_unknown_attributes?,


### PR DESCRIPTION
After the introduction of https://github.com/DmitryTsepelev/store_model/pull/171, 
we are still facing the issue of serializing after, #173. For `to_array_type` attributes.

Description quoted from #173: 
This PR first checks if the array is empty, before validating if all values are `StoreModel::Model` objects. For many many_base class objects