### PR TITLE
fix: serialize empty has-many array

### DIFF
--- a/lib/store_model/types/many_base.rb
+++ b/lib/store_model/types/many_base.rb
@@ -40,11 +40,14 @@ module StoreModel
       def serialize(value)
         case value
         when Array
-          return ActiveSupport::JSON.encode(value) unless value.all? { |v| v.is_a?(StoreModel::Model) }
+          if value.any? && value.all? { |v| v.is_a?(StoreModel::Model) }
+            ActiveSupport::JSON.encode(value,
+                                       serialize_unknown_attributes: value.first.serialize_unknown_attributes?,
+                                       serialize_enums_using_as_json: value.first.serialize_enums_using_as_json?)
 
-          ActiveSupport::JSON.encode(value,
-                                     serialize_unknown_attributes: value.first.serialize_unknown_attributes?,
-                                     serialize_enums_using_as_json: value.first.serialize_enums_using_as_json?)
+          else
+            ActiveSupport::JSON.encode(value)
+          end
         else
           super
         end

--- a/lib/store_model/types/many_base.rb
+++ b/lib/store_model/types/many_base.rb
@@ -40,14 +40,11 @@ module StoreModel
       def serialize(value)
         case value
         when Array
-          if value.any? && value.all? { |v| v.is_a?(StoreModel::Model) }
-            ActiveSupport::JSON.encode(value,
-                                       serialize_unknown_attributes: value.first.serialize_unknown_attributes?,
-                                       serialize_enums_using_as_json: value.first.serialize_enums_using_as_json?)
+          return ActiveSupport::JSON.encode(value) if value.empty? || value.any? { |v| !v.is_a?(StoreModel::Model) }
 
-          else
-            ActiveSupport::JSON.encode(value)
-          end
+          ActiveSupport::JSON.encode(value,
+                                     serialize_unknown_attributes: value.first.serialize_unknown_attributes?,
+                                     serialize_enums_using_as_json: value.first.serialize_enums_using_as_json?)
         else
           super
         end

--- a/spec/store_model/types/many_spec.rb
+++ b/spec/store_model/types/many_spec.rb
@@ -166,6 +166,12 @@ RSpec.describe StoreModel::Types::Many do
       include_examples "serialize examples"
     end
 
+    context "when any empty Array is passed" do
+      let(:value) { [] }
+
+      it { is_expected.to eq("[]") }
+    end
+
     context "when String is passed" do
       let(:value) { ActiveSupport::JSON.encode(attributes_array) }
       include_examples "serialize examples"

--- a/spec/store_model/types/many_spec.rb
+++ b/spec/store_model/types/many_spec.rb
@@ -168,8 +168,9 @@ RSpec.describe StoreModel::Types::Many do
 
     context "when any empty Array is passed" do
       let(:value) { [] }
+      let(:attributes_array) { [] }
 
-      it { is_expected.to eq("[]") }
+      include_examples "serialize examples"
     end
 
     context "when String is passed" do


### PR DESCRIPTION
Fixes https://github.com/DmitryTsepelev/store_model/issues/174

Root cause:

```ruby
[].all? # => true
[].any? # => false
[ StoreModel::Model.allocate ].all? { |v| v.is_a?(StoreModel::Model) # => true
```

So, to check if all are StoreModel::Model, we need to
1. (new) check the array has something in it
2. check that everything in it is a StoreModel::Model