### PR TITLE
Fixed issues with enum that contains type float

### DIFF
--- a/lib/store_model/types/enum_type.rb
+++ b/lib/store_model/types/enum_type.rb
@@ -34,7 +34,7 @@ module StoreModel
 
         case value
         when String, Symbol then cast_symbol_value(value)
-        when Integer then cast_integer_value(value)
+        when Integer, Float then cast_integer_value(value)
         else
           raise StoreModel::Types::CastError,
                 "failed casting #{value.inspect}, only String, Symbol or " \

--- a/spec/store_model/types/enum_type_spec.rb
+++ b/spec/store_model/types/enum_type_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe StoreModel::Types::EnumType do
   let(:type) { described_class.new({ active: 1, archived: 0 }, raise_on_invalid_values) }
+  let(:float_type) { described_class.new({ pi: 3.14, tau: 6.28 }, raise_on_invalid_values) }
   let(:raise_on_invalid_values) { true }
 
   describe "#type" do
@@ -95,15 +96,33 @@ RSpec.describe StoreModel::Types::EnumType do
 
       it { is_expected.to be_nil }
     end
+  end
 
-    context "when instance of illegal class is passed" do
-      let(:value) { 3.5 }
+  describe "float#cast_value" do
+    subject { float_type.cast_value(value) }
 
-      it "raises exception" do
-        expect { subject }.to raise_error(
-          StoreModel::Types::CastError,
-          "failed casting #{value}, only String, Symbol or Integer instances are allowed"
-        )
+    context "when Float is passed" do
+      let(:value) { 3.14 }
+
+      it { is_expected.to eq(3.14) }
+
+      context "when value is not in the list" do
+        let(:value) { 1.5 }
+
+        context "when raise_on_invalid_values is true" do
+          it "raises exception" do
+            expect { subject }.to raise_error(
+              ArgumentError,
+              "invalid value '#{value}' is assigned"
+            )
+          end
+        end
+
+        context "when raise_on_invalid_values is false" do
+          let(:raise_on_invalid_values) { false }
+
+          it { is_expected.to eq(value) }
+        end
       end
     end
   end


### PR DESCRIPTION
When creating enums that contains enum value type float, it throws errors of invalid type. This PR fixes the issue.
# Details:

I am having a scenario where I need my enum to be defined as { key => float } mapping.
This is my class

```
class Inputs
    include StoreModel::Model

    attribute :in_temp, :float, default: 29
    attribute :ext_temp, :float, default: 50
    attribute :rel_humid, :float, default: 70
    attribute :ins_thick, :float, default: 10

    enum :surf_emis, in: {
      high_surface: '10.0',
      medium_surface: '8.0',
      low_surface: '5.7'
    }, default: :medium_surface

    validates :in_temp, :ext_temp, :rel_humid, :surf_emis, :ins_thick, presence: true
  end
```

Now the issue is,
It only works if keys value pair is { key => integer }, but for integer I can not handle value `5.7`
I tried using string but it also throws error.
I tried using float but it also throws error.

Only working case is integer which is not applicable in my case.

[Issue reported](https://github.com/DmitryTsepelev/store_model/issues/185)