### PR TITLE
fix `accepts_nested_attributes_for` triggering db connection in rails 7.2

### DIFF
--- a/lib/store_model/nested_attributes.rb
+++ b/lib/store_model/nested_attributes.rb
@@ -14,7 +14,7 @@ module StoreModel
       end
 
       # add storemodel type of attribute if it is storemodel type
-      def attribute(name, type=nil, **)
+      def attribute(name, type = nil, **)
         store_model_attribute_types[name.to_s] = type if type.is_a?(Types::Base)
         super
       end

--- a/lib/store_model/types.rb
+++ b/lib/store_model/types.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "store_model/types/polymorphic_helper"
+require "store_model/types/base"
 
 require "store_model/types/one_base"
 require "store_model/types/one"

--- a/lib/store_model/types/base.rb
+++ b/lib/store_model/types/base.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "active_model"
+
+module StoreModel
+  module Types
+    # Base type for StoreModel::Model
+    class Base < ActiveModel::Type::Value
+      attr_reader :model_klass
+
+      # Returns type
+      #
+      # @return [Symbol]
+      def type
+        raise NotImplementedError
+      end
+
+      protected
+
+      def raise_cast_error(_value)
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/store_model/types/many_base.rb
+++ b/lib/store_model/types/many_base.rb
@@ -4,18 +4,8 @@ require "active_model"
 
 module StoreModel
   module Types
-    # Implements ActiveModel::Type::Value type for handling an array of
-    # StoreModel::Model
-    class ManyBase < ActiveModel::Type::Value
-      attr_reader :model_klass
-
-      # Returns type
-      #
-      # @return [Symbol]
-      def type
-        raise NotImplementedError
-      end
-
+    # Implements type for handling an array of StoreModel::Model
+    class ManyBase < Base
       # Casts +value+ from DB or user to StoreModel::Model instance
       #
       # @param value [Object] a value to cast
@@ -67,10 +57,6 @@ module StoreModel
       end
 
       def cast_model_type_value(_value)
-        raise NotImplementedError
-      end
-
-      def raise_cast_error(_value)
         raise NotImplementedError
       end
 

--- a/lib/store_model/types/one_base.rb
+++ b/lib/store_model/types/one_base.rb
@@ -4,17 +4,8 @@ require "active_model"
 
 module StoreModel
   module Types
-    # Implements ActiveModel::Type::Value type for handling an instance of StoreModel::Model
-    class OneBase < ActiveModel::Type::Value
-      attr_reader :model_klass
-
-      # Returns type
-      #
-      # @return [Symbol]
-      def type
-        raise NotImplementedError
-      end
-
+    # Implements type for handling an instance of StoreModel::Model
+    class OneBase < Base
       # Casts +value+ from DB or user to StoreModel::Model instance
       #
       # @param value [Object] a value to cast
@@ -35,10 +26,6 @@ module StoreModel
       end
 
       protected
-
-      def raise_cast_error(_value)
-        raise NotImplementedError
-      end
 
       def model_instance(_value)
         raise NotImplementedError

--- a/spec/store_model/nested_attributes_spec.rb
+++ b/spec/store_model/nested_attributes_spec.rb
@@ -535,7 +535,8 @@ RSpec.describe StoreModel::NestedAttributes do
           end
         end
 
-        it { expect { subject }.to raise_error(ActiveRecord::StatementInvalid) }
+        it { expect { subject }.not_to(raise_error) }
+        it { expect(subject.instance_methods).to(include(:suppliers_attributes=)) }
       end
     end
   end


### PR DESCRIPTION
manually store types of attributes defined by storemodel and use it for nested attributes preprocessing when db connection of activerecord model is not available.

add single types/base to simplify storemodel attribute detection.