### PR TITLE
Union types: Convenience layer over OneOf

### DIFF
--- a/docs/unions.md
+++ b/docs/unions.md
@@ -1,0 +1,98 @@
+
+### Unions
+
+For a common pattern where you want to select a model based on a discriminator field (like a `type` field), StoreModel provides a `union` method that wraps `OneOf`.
+
+Note the database field must have a default value of `nil` or be a value hash, an empty hash will cause errors because it doesn't have a discriminator.
+
+```ruby
+class Dog
+  include StoreModel::Model
+
+  discriminator_attribute value: "dog"
+
+  attribute :breed, :string
+  attribute :good_boy, :boolean, default: true
+end
+
+class Cat
+  include StoreModel::Model
+
+  discriminator_attribute value: "cat"
+
+  attribute :color, :string
+  attribute :lives, :integer, default: 9
+end
+
+class Reptile
+  include StoreModel::Model
+
+  discriminator_attribute value: "reptile"
+
+  attribute :species, :string
+  attribute :cold_blooded, :boolean, default: true
+end
+
+# Create a union type
+AnimalType = StoreModel.union([Dog, Cat, Reptile])
+
+class Pet < ApplicationRecord
+  attribute :animal, AnimalType.to_type
+end
+
+class Zoo < ApplicationRecord
+  attribute :animals, AnimalType.to_array_type
+end
+```
+
+Now you can work with different animal types seamlessly:
+
+```ruby
+# Create pets with different types
+dog_owner = Pet.create!(animal: { type: 'dog', breed: 'Golden Retriever' })
+cat_owner = Pet.create!(animal: { type: 'cat', color: 'orange', lives: 8 })
+
+# The correct model class is automatically instantiated
+dog_owner.animal # => #<Dog type: "dog", breed: "Golden Retriever", good_boy: true>
+cat_owner.animal # => #<Cat type: "cat", color: "orange", lives: 8>
+
+# Works with arrays too
+zoo = Zoo.create!(
+  animals: [
+    { type: 'dog', breed: 'Husky' },
+    { type: 'cat', color: 'black' },
+    { type: 'reptile', species: 'Iguana' }
+  ]
+)
+
+zoo.animals[0] # => #<Dog ...>
+zoo.animals[1] # => #<Cat ...>
+zoo.animals[2] # => #<Reptile ...>
+```
+
+#### Customizing the Union Type
+
+You can customize which field is used as the discriminator:
+
+```ruby
+class PaymentMethod
+  include StoreModel::Model
+
+  discriminator_attribute :kind, value: 'credit_card'
+  attribute :card_number, :string
+end
+
+class BankTransfer
+  include StoreModel::Model
+
+  discriminator_attribute :kind, value: 'bank_transfer'
+  attribute :account_number, :string
+end
+
+# Use 'kind' as discriminator field
+PaymentType = StoreModel.union([PaymentMethod, BankTransfer], discriminator: 'kind')
+
+class Order < ApplicationRecord
+  attribute :payment, PaymentType.to_type
+end
+```

--- a/lib/store_model.rb
+++ b/lib/store_model.rb
@@ -25,35 +25,45 @@ module StoreModel # :nodoc:
         [cls._default_attributes[discriminator]&.value, cls]
       end
 
+      validate_missing_discriminators!(discriminator, discriminators_and_classes)
+      validate_duplicate_discriminators!(discriminators_and_classes)
+
+      union_one_of(discriminator, Hash[discriminators_and_classes])
+    end
+
+    private
+
+    def validate_missing_discriminators!(discriminator, discriminators_and_classes)
       missing_discriminator_classes = discriminators_and_classes.select do |(discriminator_value, _cls)|
         discriminator_value.blank?
       end.map(&:last)
 
-      if missing_discriminator_classes.any?
-        raise "discriminator_attribute not set for #{discriminator} on #{missing_discriminator_classes.join(', ')}"
-      end
+      return if missing_discriminator_classes.empty?
 
+      raise "discriminator_attribute not set for #{discriminator} on #{missing_discriminator_classes.join(', ')}"
+    end
+
+    def validate_duplicate_discriminators!(discriminators_and_classes)
       discriminator_counts = discriminators_and_classes.group_by(&:first)
       duplicates = discriminator_counts.select { |_discriminator_value, pairs| pairs.length > 1 }
 
-      if duplicates.any?
-        duplicate_messages = duplicates.map do |discriminator_value, pairs|
-          classes = pairs.map(&:last).map(&:name).join(", ")
-          "#{discriminator_value.inspect} => [#{classes}]"
-        end
-        raise "Duplicate discriminator values found: #{duplicate_messages.join('; ')}"
+      return if duplicates.empty?
+
+      duplicate_messages = duplicates.map do |discriminator_value, pairs|
+        classes = pairs.map(&:last).map(&:name).join(", ")
+        "#{discriminator_value.inspect} => [#{classes}]"
       end
 
-      class_map = Hash[discriminators_and_classes]
+      raise "Duplicate discriminator values found: #{duplicate_messages.join('; ')}"
+    end
 
+    def union_one_of(discriminator, class_map)
       Types::OneOf.new do |attributes|
         next nil unless attributes
 
         discriminator_value = attributes.with_indifferent_access[discriminator]
 
-        if discriminator_value.blank?
-          raise ArgumentError, "Missing discriminator attribute #{discriminator} for union"
-        end
+        raise ArgumentError, "Missing discriminator attribute #{discriminator} for union" if discriminator_value.blank?
 
         cls = class_map[discriminator_value]
         raise ArgumentError, "Unknown discriminator value for union: #{discriminator_value}" if cls.blank?

--- a/lib/store_model.rb
+++ b/lib/store_model.rb
@@ -15,5 +15,51 @@ module StoreModel # :nodoc:
     def one_of(&block)
       Types::OneOf.new(&block)
     end
+
+    # Creates a union type for polymorphic attributes
+    # @param klasses [Array<Class>] array of classes that can be used
+    # @param discriminator [String, Symbol] the attribute key to check for type (default: 'type')
+    # @return instance [Types::OneOf]
+    def union(klasses, discriminator: "type")
+      discriminators_and_classes = klasses.map do |cls|
+        [cls._default_attributes[discriminator]&.value, cls]
+      end
+
+      missing_discriminator_classes = discriminators_and_classes.select do |(discriminator_value, _cls)|
+        discriminator_value.blank?
+      end.map(&:last)
+
+      if missing_discriminator_classes.any?
+        raise "discriminator_attribute not set for #{discriminator} on #{missing_discriminator_classes.join(', ')}"
+      end
+
+      discriminator_counts = discriminators_and_classes.group_by(&:first)
+      duplicates = discriminator_counts.select { |_discriminator_value, pairs| pairs.length > 1 }
+
+      if duplicates.any?
+        duplicate_messages = duplicates.map do |discriminator_value, pairs|
+          classes = pairs.map(&:last).map(&:name).join(", ")
+          "#{discriminator_value.inspect} => [#{classes}]"
+        end
+        raise "Duplicate discriminator values found: #{duplicate_messages.join('; ')}"
+      end
+
+      class_map = Hash[discriminators_and_classes]
+
+      Types::OneOf.new do |attributes|
+        next nil unless attributes
+
+        discriminator_value = attributes.with_indifferent_access[discriminator]
+
+        if discriminator_value.blank?
+          raise ArgumentError, "Missing discriminator attribute #{discriminator} for union"
+        end
+
+        cls = class_map[discriminator_value]
+        raise ArgumentError, "Unknown discriminator value for union: #{discriminator_value}" if cls.blank?
+
+        cls
+      end
+    end
   end
 end

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -37,7 +37,7 @@ module StoreModel
       # @param discriminator [Symbol, String] attribute name (default: :type)
       # @param type [Symbol, String] attribute type (default: :string)
       # @param value [String] the discriminator value
-      def discriminator_attribute(discriminator = "type", type: :string, value:)
+      def discriminator_attribute(discriminator = "type", value:, type: :string)
         attribute discriminator, type, default: value
       end
     end

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -32,6 +32,14 @@ module StoreModel
       def from_values(values)
         to_array_type.cast_value(values)
       end
+
+      # Defines a discriminator attribute with a value
+      # @param discriminator [Symbol, String] attribute name (default: :type)
+      # @param type [Symbol, String] attribute type (default: :string)
+      # @param value [String] the discriminator value
+      def discriminator_attribute(discriminator = "type", type: :string, value:)
+        attribute discriminator, type, default: value
+      end
     end
 
     attr_accessor :parent

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -6,6 +6,7 @@ ActiveRecord::Schema.define(version: 2019_02_216_153105) do
     t.references :store, null: true
     t.json :configuration, default: {}
     t.json :product_configuration, default: {}
+    t.json :union_test, default: nil
   end
 
   create_table :stores do |t|

--- a/spec/store_model/discriminator_attribute_spec.rb
+++ b/spec/store_model/discriminator_attribute_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "StoreModel::Model.discriminator_attribute" do
+  describe "basic usage" do
+    let(:dog_class) do
+      Class.new do
+        include StoreModel::Model
+
+        discriminator_attribute value: "dog"
+        attribute :breed, :string
+      end
+    end
+
+    it "creates a type attribute with the specified default" do
+      dog = dog_class.new
+      expect(dog.type).to eq("dog")
+    end
+
+    it "allows overriding the type value" do
+      dog = dog_class.new(type: "puppy")
+      expect(dog.type).to eq("puppy")
+    end
+
+    it "includes type in attributes" do
+      dog = dog_class.new
+      expect(dog.attributes).to include("type" => "dog")
+    end
+  end
+
+  describe "custom attribute name" do
+    let(:payment_class) do
+      Class.new do
+        include StoreModel::Model
+
+        discriminator_attribute :kind, value: "credit_card"
+        attribute :number, :string
+      end
+    end
+
+    it "creates attribute with custom name" do
+      payment = payment_class.new
+      expect(payment.kind).to eq("credit_card")
+    end
+
+    it "does not create a 'type' attribute" do
+      payment = payment_class.new
+      expect(payment.attributes).not_to have_key("type")
+      expect(payment.attributes).to include("kind" => "credit_card")
+    end
+  end
+
+  describe "custom attribute type" do
+    let(:version_class) do
+      Class.new do
+        include StoreModel::Model
+
+        discriminator_attribute :version, type: :integer, value: 1
+        attribute :data, :string
+      end
+    end
+
+    let(:priority_class) do
+      Class.new do
+        include StoreModel::Model
+
+        discriminator_attribute :priority, type: :integer, value: 10
+        attribute :message, :string
+      end
+    end
+
+    it "creates an integer discriminator attribute" do
+      instance = version_class.new
+      expect(instance.version).to eq(1)
+      expect(instance.version).to be_a(Integer)
+    end
+
+    it "allows overriding the integer value" do
+      instance = version_class.new(version: 2)
+      expect(instance.version).to eq(2)
+    end
+
+    it "includes integer type in attributes" do
+      instance = version_class.new
+      expect(instance.attributes).to include("version" => 1)
+    end
+  end
+end

--- a/spec/store_model/union_spec.rb
+++ b/spec/store_model/union_spec.rb
@@ -1,0 +1,287 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "StoreModel.union ActiveRecord Integration" do
+  describe "single union attribute" do
+    before do
+      stub_const("EmailNotification", Class.new do
+        include StoreModel::Model
+
+        discriminator_attribute :channel, value: "email"
+        attribute :to_address, :string
+        attribute :subject, :string
+      end)
+
+      stub_const("SmsNotification", Class.new do
+        include StoreModel::Model
+
+        discriminator_attribute :channel, value: "sms"
+        attribute :phone_number, :string
+        attribute :message, :string
+      end)
+
+      stub_const("PushNotification", Class.new do
+        include StoreModel::Model
+
+        discriminator_attribute :channel, value: "push"
+        attribute :device_token, :string
+        attribute :title, :string
+        attribute :body, :string
+      end)
+    end
+
+    let(:notification_union) do
+      StoreModel.union([EmailNotification, SmsNotification, PushNotification], discriminator: "channel")
+    end
+
+    let(:product_class) do
+      union = notification_union
+      build_custom_product_class do
+        attribute :union_test, union.to_type
+      end
+    end
+
+    it "persists and retrieves email notification" do
+      product = product_class.create!(
+        union_test: EmailNotification.new(
+          to_address: "user@example.com",
+          subject: "Hello World"
+        )
+      )
+
+      reloaded = product_class.find(product.id)
+      expect(reloaded.union_test).to be_a(EmailNotification)
+      expect(reloaded.union_test.channel).to eq("email")
+      expect(reloaded.union_test.to_address).to eq("user@example.com")
+      expect(reloaded.union_test.subject).to eq("Hello World")
+    end
+
+    it "persists and retrieves sms notification" do
+      product = product_class.create!(
+        union_test: SmsNotification.new(
+          phone_number: "+1234567890",
+          message: "Your code is 123456"
+        )
+      )
+
+      reloaded = product_class.find(product.id)
+      expect(reloaded.union_test).to be_a(SmsNotification)
+      expect(reloaded.union_test.channel).to eq("sms")
+      expect(reloaded.union_test.phone_number).to eq("+1234567890")
+      expect(reloaded.union_test.message).to eq("Your code is 123456")
+    end
+
+    it "persists and retrieves push notification" do
+      product = product_class.create!(
+        union_test: PushNotification.new(
+          device_token: "abc123",
+          title: "New Message",
+          body: "You have a new message"
+        )
+      )
+
+      reloaded = product_class.find(product.id)
+
+      expect(reloaded.union_test).to be_a(PushNotification)
+      expect(reloaded.union_test.channel).to eq("push")
+      expect(reloaded.union_test.device_token).to eq("abc123")
+      expect(reloaded.union_test.title).to eq("New Message")
+      expect(reloaded.union_test.body).to eq("You have a new message")
+    end
+
+    it "raises error for unknown channel" do
+      expect do
+        product_class.create!(
+          union_test: { channel: "unknown" }
+        )
+      end.to raise_error(ArgumentError, "Unknown discriminator value for union: unknown")
+    end
+  end
+
+  describe "integer discriminator" do
+    before do
+      stub_const("BasicPlan", Class.new do
+        include StoreModel::Model
+
+        discriminator_attribute :tier, type: :integer, value: 1
+        attribute :features, :integer, default: 5
+        attribute :price, :float, default: 9.99
+      end)
+
+      stub_const("ProPlan", Class.new do
+        include StoreModel::Model
+
+        discriminator_attribute :tier, type: :integer, value: 2
+        attribute :features, :integer, default: 20
+        attribute :price, :float, default: 29.99
+        attribute :support_level, :string, default: "email"
+      end)
+
+      stub_const("EnterprisePlan", Class.new do
+        include StoreModel::Model
+
+        discriminator_attribute :tier, type: :integer, value: 3
+        attribute :features, :integer, default: -1 # unlimited
+        attribute :price, :float, default: 99.99
+        attribute :support_level, :string, default: "phone"
+        attribute :sla, :boolean, default: true
+      end)
+    end
+
+    let(:plan_union) { StoreModel.union([BasicPlan, ProPlan, EnterprisePlan], discriminator: "tier") }
+
+    let(:product_class) do
+      union = plan_union
+      build_custom_product_class do
+        attribute :union_test, union.to_type
+      end
+    end
+
+    it "works with integer discriminators" do
+      basic = product_class.create!(union_test: { tier: 1 })
+      pro = product_class.create!(union_test: { tier: 2, support_level: "chat" })
+      enterprise = product_class.create!(union_test: { tier: 3 })
+
+      basic_reloaded = product_class.find(basic.id)
+      expect(basic_reloaded.union_test).to be_a(BasicPlan)
+      expect(basic_reloaded.union_test.tier).to eq(1)
+      expect(basic_reloaded.union_test.features).to eq(5)
+      expect(basic_reloaded.union_test.price).to eq(9.99)
+
+      pro_reloaded = product_class.find(pro.id)
+      expect(pro_reloaded.union_test).to be_a(ProPlan)
+      expect(pro_reloaded.union_test.tier).to eq(2)
+      expect(pro_reloaded.union_test.support_level).to eq("chat")
+
+      enterprise_reloaded = product_class.find(enterprise.id)
+      expect(enterprise_reloaded.union_test).to be_a(EnterprisePlan)
+      expect(enterprise_reloaded.union_test.tier).to eq(3)
+      expect(enterprise_reloaded.union_test.sla).to eq(true)
+    end
+  end
+
+  describe "null handling" do
+    before do
+      stub_const("ConfigV1", Class.new do
+        include StoreModel::Model
+
+        discriminator_attribute :version, value: "v1"
+        attribute :setting, :string
+      end)
+    end
+
+    let(:config_union) { StoreModel.union([ConfigV1], discriminator: "version") }
+
+    let(:product_class) do
+      union = config_union
+      build_custom_product_class do
+        attribute :union_test, union.to_type
+      end
+    end
+
+    it "handles nil configuration" do
+      product = product_class.create!(union_test: nil)
+
+      reloaded = product_class.find(product.id)
+      expect(reloaded.union_test).to be_nil
+    end
+  end
+
+  describe "duplicate discriminator validation" do
+    it "raises error when multiple classes have the same discriminator value" do
+      stub_const("DuplicateA", Class.new do
+        include StoreModel::Model
+        discriminator_attribute :kind, value: "same"
+        attribute :field_a, :string
+      end)
+
+      stub_const("DuplicateB", Class.new do
+        include StoreModel::Model
+        discriminator_attribute :kind, value: "same"
+        attribute :field_b, :string
+      end)
+
+      stub_const("DuplicateC", Class.new do
+        include StoreModel::Model
+        discriminator_attribute :kind, value: "different"
+        attribute :field_c, :string
+      end)
+
+      expect do
+        StoreModel.union([DuplicateA, DuplicateB, DuplicateC], discriminator: "kind")
+      end.to raise_error(RuntimeError, 'Duplicate discriminator values found: "same" => [DuplicateA, DuplicateB]')
+    end
+
+    it "raises error for duplicate integer discriminators" do
+      stub_const("IntDupA", Class.new do
+        include StoreModel::Model
+        discriminator_attribute :version, type: :integer, value: 1
+        attribute :data, :string
+      end)
+
+      stub_const("IntDupB", Class.new do
+        include StoreModel::Model
+        discriminator_attribute :version, type: :integer, value: 1
+        attribute :info, :string
+      end)
+
+      expect do
+        StoreModel.union([IntDupA, IntDupB], discriminator: "version")
+      end.to raise_error(RuntimeError, "Duplicate discriminator values found: 1 => [IntDupA, IntDupB]")
+    end
+  end
+
+  describe "missing discriminator validation" do
+    it "raises error when discriminator attribute is not defined" do
+      stub_const("NoDiscriminator", Class.new do
+        include StoreModel::Model
+        attribute :field, :string
+      end)
+
+      stub_const("HasDiscriminator", Class.new do
+        include StoreModel::Model
+        discriminator_attribute :kind, value: "valid"
+        attribute :field, :string
+      end)
+
+      expect do
+        StoreModel.union([NoDiscriminator, HasDiscriminator], discriminator: "kind")
+      end.to raise_error(RuntimeError, "discriminator_attribute not set for kind on NoDiscriminator")
+    end
+
+    it "raises error when looking for non-existent discriminator key" do
+      stub_const("WrongKey", Class.new do
+        include StoreModel::Model
+        discriminator_attribute :type, value: "test"
+        attribute :field, :string
+      end)
+
+      expect do
+        StoreModel.union([WrongKey], discriminator: "missing_key")
+      end.to raise_error(RuntimeError, "discriminator_attribute not set for missing_key on WrongKey")
+    end
+
+    it "raises error for multiple classes missing discriminator" do
+      stub_const("MissingA", Class.new do
+        include StoreModel::Model
+        attribute :field_a, :string
+      end)
+
+      stub_const("MissingB", Class.new do
+        include StoreModel::Model
+        attribute :field_b, :string
+      end)
+
+      stub_const("ValidClass", Class.new do
+        include StoreModel::Model
+        discriminator_attribute value: "valid"
+        attribute :field_c, :string
+      end)
+
+      expect do
+        StoreModel.union([MissingA, MissingB, ValidClass])
+      end.to raise_error(RuntimeError, "discriminator_attribute not set for type on MissingA, MissingB")
+    end
+  end
+end


### PR DESCRIPTION
This PR implements #210 (in a slightly different way)


`StoreModel.union([Dog, Cat, Reptile]).to_type` to get a type that can hold one of `Dog`, `Cat` or `Reptile` by an discriminator attribute `"type"`.

Add `discriminator_attribute value: "dog"` to set up the discriminator on the `StoreModel::Model`s.

The discriminator key is configurable in both places, as is the value of the attribute.