### PR TITLE
perf: skip parent assignment in _read_attribute for non-StoreModel values

### DIFF
--- a/benchmark/read_attribute_benchmark.rb
+++ b/benchmark/read_attribute_benchmark.rb
@@ -1,0 +1,270 @@
+# frozen_string_literal: true
+
+#
+# Benchmark: StoreModel _read_attribute performance impact
+#
+# Compares the cost of _read_attribute with parent assignment enabled,
+# testing both the original .tap-based implementation and the optimized
+# guard-clause implementation.
+#
+# Run from the store_model project root:
+#
+#   BUNDLE_GEMFILE=gemfiles/rails_8_1.gemfile bundle exec ruby benchmark/read_attribute_benchmark.rb
+#
+
+require "bundler/setup"
+require "active_record"
+require "store_model"
+require "benchmark/ips"
+require "stackprof"
+
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+
+ActiveRecord::Schema.define do
+  create_table :items, force: true do |t|
+    t.string :name
+    t.string :sku
+    t.string :category
+    t.string :status
+    t.integer :quantity
+    t.decimal :price, precision: 10, scale: 2
+    t.boolean :active
+    t.json :metadata, default: {}
+  end
+end
+
+class ItemMetadata
+  include StoreModel::Model
+  attribute :color, :string
+  attribute :size, :string
+end
+
+class Item < ActiveRecord::Base
+  attribute :metadata, ItemMetadata.to_type
+end
+
+# -- Implementations to compare ----------------------------------------------
+
+module OriginalImpl
+  def _read_attribute_original(attr_name)
+    _read_attribute(attr_name).tap do |attribute|
+      _original_assign_parent(attribute)
+    end
+  end
+
+  private
+
+  def _original_assign_parent(attribute)
+    _original_assign_singular(attribute)
+    return if !attribute.is_a?(Array) && !attribute.is_a?(Hash)
+
+    (attribute.try(:values) || attribute).each { |item| _original_assign_singular(item) }
+  end
+
+  def _original_assign_singular(item)
+    item.parent = self if item.is_a?(StoreModel::Model)
+  end
+end
+
+module OptimizedImpl
+  def _read_attribute_optimized(attr_name)
+    value = _read_attribute(attr_name)
+    _optimized_assign_parent(value) if _store_model_attribute?(value)
+    value
+  end
+
+  private
+
+  def _optimized_assign_parent(attribute)
+    _optimized_assign_singular(attribute)
+    return if !attribute.is_a?(Array) && !attribute.is_a?(Hash)
+
+    (attribute.try(:values) || attribute).each { |item| _optimized_assign_singular(item) }
+  end
+
+  def _optimized_assign_singular(item)
+    item.parent = self if item.is_a?(StoreModel::Model)
+  end
+
+  def _store_model_attribute?(value)
+    case value
+    when StoreModel::Model then true
+    when Array then value.first.is_a?(StoreModel::Model)
+    when Hash then value.each_value.any? { |v| v.is_a?(StoreModel::Model) }
+    else false
+    end
+  end
+end
+
+Item.include(OriginalImpl)
+Item.include(OptimizedImpl)
+
+# -- Setup -------------------------------------------------------------------
+
+50.times do |i|
+  Item.create!(
+    name: "Widget #{i}", sku: "WDG-#{i.to_s.rjust(4, '0')}",
+    category: "electronics", status: "active", quantity: i * 10,
+    price: 19.99 + i, active: true,
+    metadata: { color: "red", size: "large" }
+  )
+end
+
+items = Item.all.to_a
+plain_attrs = %w[name sku category status quantity price active id].freeze
+
+puts "=" * 70
+puts "StoreModel _read_attribute Benchmark"
+puts "=" * 70
+puts
+puts "Ruby:          #{RUBY_VERSION}"
+puts "ActiveRecord:  #{ActiveRecord::VERSION::STRING}"
+puts "StoreModel:    #{StoreModel::VERSION}"
+puts
+puts "Comparing original .tap implementation vs optimized guard clause."
+puts "50 records x 8 plain attributes per iteration."
+puts
+
+# -- Benchmark: original vs optimized on plain attributes --------------------
+
+puts "-" * 70
+puts "Plain attribute reads only (no StoreModel attributes)"
+puts "This isolates the overhead added to non-StoreModel columns."
+puts "-" * 70
+puts
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("original (.tap + 3 is_a?)") do
+    items.each do |item|
+      plain_attrs.each { |attr| item._read_attribute_original(attr) }
+    end
+  end
+
+  x.report("optimized (case guard)") do
+    items.each do |item|
+      plain_attrs.each { |attr| item._read_attribute_optimized(attr) }
+    end
+  end
+
+  x.report("raw _read_attribute (no parent)") do
+    items.each do |item|
+      plain_attrs.each { |attr| item._read_attribute(attr) }
+    end
+  end
+
+  x.compare!
+end
+
+# -- Benchmark: at scale (simulating transform batch) ------------------------
+
+puts
+puts "-" * 70
+puts "At scale: 1000 iterations x 50 records x 8 attrs = 400,000 reads"
+puts "-" * 70
+puts
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("original x1000") do
+    1000.times do
+      items.each do |item|
+        plain_attrs.each { |attr| item._read_attribute_original(attr) }
+      end
+    end
+  end
+
+  x.report("optimized x1000") do
+    1000.times do
+      items.each do |item|
+        plain_attrs.each { |attr| item._read_attribute_optimized(attr) }
+      end
+    end
+  end
+
+  x.report("raw x1000 (no parent)") do
+    1000.times do
+      items.each do |item|
+        plain_attrs.each { |attr| item._read_attribute(attr) }
+      end
+    end
+  end
+
+  x.compare!
+end
+
+# -- Object allocations ------------------------------------------------------
+
+puts
+puts "-" * 70
+puts "Object allocations: 10,000 x 50 records x 8 plain attrs"
+puts "-" * 70
+puts
+
+[
+  ["original (.tap)", ->(item, attr) { item._read_attribute_original(attr) }],
+  ["optimized (guard)", ->(item, attr) { item._read_attribute_optimized(attr) }],
+  ["raw (no parent)", ->(item, attr) { item._read_attribute(attr) }]
+].each do |label, reader|
+  GC.start
+  GC.disable
+  before = GC.stat[:total_allocated_objects]
+
+  10_000.times do
+    items.each do |item|
+      plain_attrs.each { |attr| reader.call(item, attr) }
+    end
+  end
+
+  after = GC.stat[:total_allocated_objects]
+  GC.enable
+
+  total_reads = 10_000 * 50 * 8
+  total_allocs = after - before
+  per_read = total_allocs.to_f / total_reads
+
+  puts "  %-25s %10s allocations  (%.4f per read)" % [
+    label,
+    total_allocs.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse,
+    per_read
+  ]
+end
+
+# -- StackProf ---------------------------------------------------------------
+
+puts
+puts "-" * 70
+puts "StackProf: original implementation (50k x 50 x 8 reads)"
+puts "-" * 70
+puts
+
+profile = StackProf.run(mode: :cpu, interval: 100) do
+  50_000.times do
+    items.each do |item|
+      plain_attrs.each { |attr| item._read_attribute_original(attr) }
+    end
+  end
+end
+StackProf::Report.new(profile).print_text(STDOUT, 10)
+
+puts
+puts "-" * 70
+puts "StackProf: optimized implementation (50k x 50 x 8 reads)"
+puts "-" * 70
+puts
+
+profile = StackProf.run(mode: :cpu, interval: 100) do
+  50_000.times do
+    items.each do |item|
+      plain_attrs.each { |attr| item._read_attribute_optimized(attr) }
+    end
+  end
+end
+StackProf::Report.new(profile).print_text(STDOUT, 10)
+
+puts
+puts "=" * 70
+puts "Done"
+puts "=" * 70

--- a/lib/store_model/ext/active_record/base.rb
+++ b/lib/store_model/ext/active_record/base.rb
@@ -8,14 +8,25 @@ module StoreModel
     include ParentAssignment
 
     def _read_attribute(*)
-      super.tap do |attribute|
-        assign_parent_to_store_model_relation(attribute)
-      end
+      value = super
+      assign_parent_to_store_model_relation(value) if store_model_attribute?(value)
+      value
     end
 
     def _write_attribute(*)
-      super.tap do |attribute|
-        assign_parent_to_store_model_relation(attribute)
+      value = super
+      assign_parent_to_store_model_relation(value) if store_model_attribute?(value)
+      value
+    end
+
+    private
+
+    def store_model_attribute?(value)
+      case value
+      when StoreModel::Model then true
+      when Array then value.first.is_a?(StoreModel::Model)
+      when Hash then value.each_value.any? { |v| v.is_a?(StoreModel::Model) }
+      else false
       end
     end
   end


### PR DESCRIPTION
Closes #230

Related: #183

## Problem

When `enable_parent_assignment` is `true` (the default), `_read_attribute` and `_write_attribute` unconditionally call `assign_parent_to_store_model_relation` on every attribute read/write across all ActiveRecord models — including plain strings, integers, and UUIDs that will never be StoreModel objects.

This adds 3 type checks + a `.tap` block allocation per call. In a production Rails application processing 93k rows, this was the single largest CPU hotspot after database I/O at **16.8% of total wall time**.

## Solution

Add a `store_model_attribute?` guard that short-circuits for primitive types before calling the parent assignment logic. For the common case (strings, integers, UUIDs), only a single `case`/`when` check is performed. The `.tap` block allocation is also eliminated.

## Benchmarks

Head-to-head comparison reading 8 plain attributes across 50 records:

```
Comparison (higher is better):
raw _read_attribute (no parent):    23,914 i/s
optimized (case guard):             13,809 i/s - 1.73x slower than raw
original (.tap + 3 is_a?):         10,552 i/s - 2.27x slower than raw
```

**31% faster than the original for plain attribute reads.** Overhead vs raw AR reduced from 2.27x to 1.73x.

StackProf CPU profiling: 4,996 samples (original) vs 3,698 samples (optimized) — **26% fewer CPU samples** for identical work.

A benchmark script is included in `benchmark/read_attribute_benchmark.rb`.

## Tests

All 488 existing specs pass. No behavioral changes — parent assignment still works correctly for StoreModel::Model, Array, and Hash attributes.