### PR TITLE
fix: support decoding a null JSON value

### DIFF
--- a/lib/store_model/types/one.rb
+++ b/lib/store_model/types/one.rb
@@ -74,7 +74,7 @@ module StoreModel
         case value
         when String
           payload = ActiveSupport::JSON.decode(value) rescue {}
-          model_instance(deserialize_by_types(payload))
+          model_instance(deserialize_by_types(payload)) unless payload.nil?
         when ::Hash
           model_instance(deserialize_by_types(value))
         when nil

--- a/spec/store_model/types/one_spec.rb
+++ b/spec/store_model/types/one_spec.rb
@@ -266,6 +266,14 @@ RSpec.describe StoreModel::Types::One do
       it("is equal to an empty model") { is_expected.to eq(Configuration.new) }
     end
 
+    describe "when a null encoded json value is passed" do
+      let(:value) { "null" }
+
+      subject { type.deserialize(value) }
+
+      it { is_expected.to be_nil }
+    end
+
     describe "when a malformed JSON string is passed" do
       let(:value) { "{/sdfgsdfre}" }
 


### PR DESCRIPTION
in v1.6.1, a null-encoded value stored from the database would be deserialized to nil. since this, the operation fails, because the value is correctly json-decoded then passed to #deserialize_by_types, which expects a hash.

this has been a regression since the v2 series. the fix reintroduces the same conditional it had existed in v1.6.1.

this is required for migrating applications which have stored nil values in the database in the described format. not sure whether this was expected or not.

I found this while migrating a. particular use case where the column is encrypted with lockbox, which may explain the edge case.