### PR TITLE
support raw hash serialization

### DIFF
--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -294,10 +294,13 @@ module StoreModel
     end
 
     def serialized_attribute(attr)
-      if attr.value.is_a? StoreModel::Model
+      case attr.value
+      when StoreModel::Model
         Types::RawJSONEncoder.new(attr.value_for_database)
-      elsif attr.value.is_a? Array
+      when Array
         serialize_array_attribute(attr.value)
+      when Hash # attribute :smth, json
+        attr.value
       else
         attr.value_for_database
       end

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -222,6 +222,30 @@ RSpec.describe StoreModel::Model do
 
       it("returns correct JSON") { is_expected.to eq(attributes.except(:model, :encrypted_serial).as_json) }
     end
+
+    context "with a plain :json attribute" do
+      let(:model_class) do
+        Class.new do
+          include StoreModel::Model
+          # equivalent to `attribute :json_value, :json` in an ActiveRecord-backed context
+          attribute :json_value, ActiveRecord::Type::Json.new
+        end
+      end
+
+      let(:instance) { model_class.new(json_value: { "foo" => "bar", "nested" => { "baz" => 1 } }) }
+
+      it "serializes the hash value as-is without double-encoding" do
+        expect(instance.as_json).to eq("json_value" => { "foo" => "bar", "nested" => { "baz" => 1 } })
+      end
+
+      context "when the value is nil" do
+        let(:instance) { model_class.new(json_value: nil) }
+
+        it "serializes nil" do
+          expect(instance.as_json).to eq("json_value" => nil)
+        end
+      end
+    end
   end
 
   describe "#blank?" do


### PR DESCRIPTION
if the attribute is set as `:json`, the raw value is a hash, and its `value_for_database` is the json hash already, which breaks `as_json` representation with nested models.