### PR TITLE
pass `#as_json` options downstream to nested attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## master
 
+- [PR #234](https://github.com/DmitryTsepelev/store_model/pull/234) fix: pass `#as_json` options downstream to nested attributes ([@HoneyryderChuck])
+
 ## 4.6.1 (2026-08-02)
 
 - [PR #233](https://github.com/DmitryTsepelev/store_model/pull/233) fix: support raw hash serialization ([@HoneyryderChuck])

--- a/lib/store_model/model.rb
+++ b/lib/store_model/model.rb
@@ -60,32 +60,30 @@ module StoreModel
     # @param options [Hash]
     #
     # @return [Hash]
-    def as_json(options = {}) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
-      serialize_unknown_attributes = if options.key?(:serialize_unknown_attributes)
+    def as_json(options = nil) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+      serialize_unknown_attributes = if options&.key?(:serialize_unknown_attributes)
                                        options[:serialize_unknown_attributes]
                                      else
                                        StoreModel.config.serialize_unknown_attributes
                                      end
 
-      serialize_enums_using_as_json = if options.key?(:serialize_enums_using_as_json)
+      serialize_enums_using_as_json = if options&.key?(:serialize_enums_using_as_json)
                                         options[:serialize_enums_using_as_json]
                                       else
                                         StoreModel.config.serialize_enums_using_as_json
                                       end
 
-      serialize_empty_attributes = if options.key?(:serialize_empty_attributes)
+      serialize_empty_attributes = if options&.key?(:serialize_empty_attributes)
                                      options[:serialize_empty_attributes]
                                    else
                                      StoreModel.config.serialize_empty_attributes
                                    end
 
-      # If the model is nested, we need to ensure that the serialization
-
       result = @attributes.keys.each_with_object({}) do |key, values|
         attr = @attributes.fetch(key)
         assign_serialization_options(attr, serialize_unknown_attributes, serialize_enums_using_as_json,
                                      serialize_empty_attributes)
-        serialized = serialized_attribute(attr)
+        serialized = serialized_attribute(attr, options)
         values[key] = serialized if serialize_empty_attributes || !serialized.nil?
       end.with_indifferent_access
 
@@ -293,27 +291,29 @@ module StoreModel
       end
     end
 
-    def serialized_attribute(attr)
+    def serialized_attribute(attr, options)
       case attr.value
       when StoreModel::Model
-        Types::RawJSONEncoder.new(attr.value_for_database)
+        attr.value.as_json(options)
       when Array
-        serialize_array_attribute(attr.value)
+        serialize_array_attribute(attr.value, options)
       when Hash # attribute :smth, json
-        attr.value
+        serialize_hash_attribute(attr.value, options)
       else
         attr.value_for_database
       end
     end
 
-    def serialize_array_attribute(array)
+    def serialize_array_attribute(array, options)
       return array.as_json unless array.any? && array.all? { |value| value.is_a?(StoreModel::Model) }
 
-      array.as_json(
-        serialize_unknown_attributes: array.first.serialize_unknown_attributes?,
-        serialize_enums_using_as_json: array.first.serialize_enums_using_as_json?,
-        serialize_empty_attributes: array.first.serialize_empty_attributes?
-      )
+      array.as_json(options)
+    end
+
+    def serialize_hash_attribute(hash, options)
+      return hash unless hash.any? && hash.values.all? { |value| value.nil? || value.is_a?(StoreModel::Model) }
+
+      hash.transform_values { |value| value&.as_json(options) }
     end
 
     def assign_serialization_options(attr, serialize_unknown_attributes, serialize_enums_using_as_json, serialize_empty_attributes) # rubocop:disable Layout/LineLength

--- a/spec/store_model/model_spec.rb
+++ b/spec/store_model/model_spec.rb
@@ -246,6 +246,202 @@ RSpec.describe StoreModel::Model do
         end
       end
     end
+
+    context "with nested models" do
+      let(:nested_class) do
+        Class.new do
+          include StoreModel::Model
+
+          attribute :color, :string
+          attribute :model, :string
+
+          enum :kind, in: { left: 1, right: 2 }
+        end
+      end
+
+      let(:model_class) do
+        nested = nested_class
+
+        Class.new do
+          include StoreModel::Model
+
+          attribute :color, :string
+          attribute :model, :string
+          attribute :one, nested.to_type
+          attribute :many, nested.to_array_type
+          attribute :hashed, nested.to_hash_type
+          attribute :poly, StoreModel.one_of { nested }.to_type
+        end
+      end
+
+      let(:nested_attributes) { { color: "red", model: nil, kind: "left" } }
+      let(:nested_json) { { "color" => "red", "model" => nil, "kind" => "left" } }
+
+      let(:instance) do
+        model_class.new(
+          color: "red",
+          model: "spaceship",
+          one: nested_attributes,
+          many: [nested_attributes],
+          hashed: { "primary" => nested_attributes },
+          poly: nested_attributes
+        )
+      end
+
+      # The same payload, built out of plain hashes and arrays, so that the
+      # serialization can be compared to the one Rails performs on them
+      let(:equivalent_hash) do
+        {
+          "color" => "red",
+          "model" => "spaceship",
+          "one" => nested_json,
+          "many" => [nested_json],
+          "hashed" => { "primary" => nested_json },
+          "poly" => nested_json
+        }.with_indifferent_access
+      end
+
+      it("returns correct JSON") { expect(instance.as_json).to eq(equivalent_hash.as_json) }
+
+      [
+        { only: %i[color one] },
+        { only: %i[one] },
+        { only: %i[color model one many hashed primary poly] },
+        { except: %i[model] },
+        { except: %i[kind primary] },
+        { except: %i[one many hashed poly] }
+      ].each do |options|
+        it "passes #{options.inspect} downstream, just like Hash#as_json does" do
+          expect(instance.as_json(options)).to eq(equivalent_hash.as_json(options))
+        end
+
+        it "passes #{options.inspect} downstream when encoding JSON" do
+          expect(instance.to_json(options)).to eq(equivalent_hash.to_json(options))
+        end
+      end
+
+      it "applies :only to nested attributes" do
+        expect(instance.as_json(only: %i[color one])).to eq(
+          "color" => "red",
+          "one" => { "color" => "red" }
+        )
+      end
+
+      it "applies :except to nested attributes" do
+        expect(instance.as_json(except: %i[model])).to eq(
+          "color" => "red",
+          "one" => { "color" => "red", "kind" => "left" },
+          "many" => [{ "color" => "red", "kind" => "left" }],
+          "hashed" => { "primary" => { "color" => "red", "kind" => "left" } },
+          "poly" => { "color" => "red", "kind" => "left" }
+        )
+      end
+
+      it "does not reuse the serialization of a previous call with different options" do
+        expect(instance.as_json(except: %i[color])["one"]).to eq("model" => nil, "kind" => "left")
+        expect(instance.as_json["one"]).to eq(nested_json)
+      end
+
+      it "passes serialize_empty_attributes downstream" do
+        expect(instance.as_json(serialize_empty_attributes: false)).to eq(
+          "color" => "red",
+          "model" => "spaceship",
+          "one" => { "color" => "red", "kind" => "left" },
+          "many" => [{ "color" => "red", "kind" => "left" }],
+          "hashed" => { "primary" => { "color" => "red", "kind" => "left" } },
+          "poly" => { "color" => "red", "kind" => "left" }
+        )
+      end
+
+      it "passes serialize_enums_using_as_json downstream" do
+        expect(instance.as_json(serialize_enums_using_as_json: false)).to eq(
+          equivalent_hash.merge(
+            "one" => nested_json.merge("kind" => 1),
+            "many" => [nested_json.merge("kind" => 1)],
+            "hashed" => { "primary" => nested_json.merge("kind" => 1) },
+            "poly" => nested_json.merge("kind" => 1)
+          ).as_json
+        )
+      end
+
+      context "with unknown attributes" do
+        let(:instance) do
+          model_class.from_value(
+            color: "red",
+            one: nested_attributes.merge(archived: true),
+            many: [nested_attributes.merge(archived: true)],
+            hashed: { "primary" => nested_attributes.merge(archived: true) },
+            poly: nested_attributes.merge(archived: true)
+          )
+        end
+
+        it "passes serialize_unknown_attributes: true downstream" do
+          json = instance.as_json(serialize_unknown_attributes: true)
+
+          expect(json["one"]).to include("archived" => true)
+          expect(json["many"].first).to include("archived" => true)
+          expect(json["hashed"]["primary"]).to include("archived" => true)
+          expect(json["poly"]).to include("archived" => true)
+        end
+
+        it "passes serialize_unknown_attributes: false downstream" do
+          json = instance.as_json(serialize_unknown_attributes: false)
+
+          expect(json["one"]).not_to include("archived")
+          expect(json["many"].first).not_to include("archived")
+          expect(json["hashed"]["primary"]).not_to include("archived")
+          expect(json["poly"]).not_to include("archived")
+        end
+
+        it "does not reuse the serialization of a previous call with different options" do
+          instance.as_json(serialize_unknown_attributes: false)
+
+          expect(instance.as_json(serialize_unknown_attributes: true)["one"]).to include("archived" => true)
+        end
+      end
+
+      # ActiveModel::Dirty#as_json, which is inserted before StoreModel::Model#as_json in the
+      # ancestors chain since ActiveModel 8.1, does not accept nil options itself.
+      if ActiveModel.version < Gem::Version.new("8.1")
+        context "when nil options are passed" do
+          it("returns correct JSON") { expect(instance.as_json(nil)).to eq(equivalent_hash.as_json) }
+        end
+      end
+
+      context "when a nested attribute has a custom type" do
+        let(:model_class) do
+          Class.new do
+            include StoreModel::Model
+
+            attribute :configuration, Configuration.to_type
+            attribute :configurations, Configuration.to_array_type
+          end
+        end
+
+        let(:instance) do
+          model_class.new(
+            configuration: { encrypted_serial: "111-222" },
+            configurations: [{ encrypted_serial: "111-222" }]
+          )
+        end
+
+        let(:encrypted_serial) { Configuration::Encrypted.new.serialize("111-222") }
+
+        it "serializes nested attributes using their database representation" do
+          json = instance.as_json
+
+          expect(json["configuration"]["encrypted_serial"]).to eq(encrypted_serial)
+          expect(json["configurations"].first["encrypted_serial"]).to eq(encrypted_serial)
+        end
+
+        it "keeps the database representation when options are passed" do
+          json = instance.as_json(only: %i[configuration configurations encrypted_serial])
+
+          expect(json["configuration"]).to eq("encrypted_serial" => encrypted_serial)
+          expect(json["configurations"]).to eq([{ "encrypted_serial" => encrypted_serial }])
+        end
+      end
+    end
   end
 
   describe "#blank?" do


### PR DESCRIPTION
this is a regression from v1.6, which causes extra options (other than the ones supported internally by store_model) not to be propagated to other store models internal to the one where #as_json has been called. this'd include .to_array_type like arrays with nested store models, as well as hashes.

Bear in mind that the default #as_json behaviour, for arrays and hashes, is to propagate options all the way down to values (see [here](https://github.com/rails/rails/blob/be96a01be47eeab57954c5a34cde5895a16185f4/activesupport/lib/active_support/core_ext/object/json.rb#L168) and [here](https://github.com/rails/rails/blob/be96a01be47eeab57954c5a34cde5895a16185f4/activesupport/lib/active_support/core_ext/object/json.rb#L193))

This patch fixes it by passing down the original set of options with which the top level model was called with.

FWIW we've been running an internal monkeypatch on `StoreModel::Model#serialized_attribute`, of the kind:

```ruby
return attr.value if attr.value.is_a?(Hash) || attr.value.is_a?(Array)
```

which is also not correct. 